### PR TITLE
fix: local builds resolve dependencySizes properly

### DIFF
--- a/src/getDependencySizeTree.js
+++ b/src/getDependencySizeTree.js
@@ -38,7 +38,7 @@ function getByteLen(normal_val) {
   return byteLen
 }
 
-function bundleSizeTree(stats) {
+function bundleSizeTree(stats, isLocal) {
   let statsTree = {
     packageName: '<root>',
     sources: [],
@@ -105,7 +105,17 @@ function bundleSizeTree(stats) {
       }
       packages.push(lastPackageName)
     }
+    // Removes the `/tmp/tmp-build...` from the split list
     packages.shift()
+    if (isLocal) {
+      // If this is a local install, the file structure is slightly different.
+      // Remote: `/tmp/tmp-build/<installPath>/node_modules` contains all the modules
+      // in a flat directory.
+      // Local: `/tmp/tmp-build/<installPath>/node_modules` is a link to the local module
+      // (named <packageName>),which also contains a `node_modules` directory (the one with the deps). This means
+      // there is an extra `node_modules` in the path that we need to account for.
+      packages.shift()
+    }
 
     let parent = statsTree
     parent.sources.push(mod.source)

--- a/src/getPackageStats.js
+++ b/src/getPackageStats.js
@@ -38,7 +38,7 @@ function getPackageJSONDetails(packageName, installPath) {
 }
 
 async function getPackageStats(packageString, options = {}) {
-  const packageName = parsePackageString(packageString).name
+  const { name: packageName, isLocal } = parsePackageString(packageString)
   const installPath = await InstallationUtils.preparePath(packageName)
 
   await InstallationUtils.installPackage(packageString, installPath, {
@@ -55,6 +55,7 @@ async function getPackageStats(packageString, options = {}) {
         name: packageName,
         installPath,
         externals,
+        isLocal,
         options: {
           customImports: options.customImports,
         },

--- a/src/utils/build.utils.js
+++ b/src/utils/build.utils.js
@@ -94,7 +94,7 @@ const BuildUtils = {
     return uniqueMissingModules
   },
 
-  async buildPackage({ name, installPath, externals, options }) {
+  async buildPackage({ name, installPath, externals, isLocal, options }) {
     let entry = {}
     if (options.splitCustomImports) {
       if (!options.customImports.length) {
@@ -209,7 +209,7 @@ const BuildUtils = {
       return {
         assets: assetStats,
         ...(!options.customImports && {
-          dependencySizes: getDependencySizes(jsonStats),
+          dependencySizes: getDependencySizes(jsonStats, isLocal),
         }),
       }
     }
@@ -219,6 +219,7 @@ const BuildUtils = {
     name,
     externals,
     installPath,
+    isLocal,
     options,
   }) {
     try {
@@ -226,6 +227,7 @@ const BuildUtils = {
         name,
         externals,
         installPath,
+        isLocal,
         options,
       })
     } catch (e) {
@@ -237,7 +239,7 @@ const BuildUtils = {
         const { missingModules } = e.extra
         const newExternals = {
           ...externals,
-          externalPackages: externals.externalPackages.concat(missingModules)
+          externalPackages: externals.externalPackages.concat(missingModules),
         }
         debug(
           '%s has missing dependencies, rebuilding without %o',

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -16,6 +16,15 @@ describe('getPackageStats', () => {
     expect(result.size).toEqual(425)
     done()
   })
+
+  test('dependencySizes', async done => {
+    const result = await getPackageStats(
+      path.resolve('./fixtures/node_modules/resolve-test')
+    )
+    expect(result.dependencySizes.length).toEqual(1)
+    expect(result.dependencySizes[0].name).toEqual('dependency')
+    done()
+  })
 })
 
 describe('getPackageExportSizes', () => {
@@ -23,7 +32,6 @@ describe('getPackageExportSizes', () => {
     const result = await getPackageExportSizes(
       path.resolve('./fixtures/node_modules/resolve-test')
     )
-    console.log(result)
     expect(result.assets.length).toEqual(4)
     expect(result.assets[0].path).toEqual('another-file-1.js')
     done()


### PR DESCRIPTION
When `getPackageStats` is run, the expected output includes composite information for npm dependency. This information is outputted in the `dependencySizes` array.

Previous to this commit, this information was not getting calculated correctly when `getPackageStats` was given a local path to install. The issue was that npm installs local package with a different directory structure than with a remote package.

Local:
`<installpath>/node_modules/package.json`
`<installpath>/node_modules/<packageName>` // this a symlink to the local package
`<installpath>/node_modules/<packageName>/package.json`
`<installpath>/node_modules/<packageName>/node_modules`

Remote:
`<installpath>/node_modules/package.json`
`<installpath>/node_modules/*` // All the packages (deps and the package itself) are install here.

The parsing logic in `getDirectorySizeTree` did not account for the extra `node_modules` in the module path and due to this was not calculating the dep tree correctly.