### PR TITLE
Use npm pack when installing local directories.

### DIFF
--- a/src/getPackageExportSizes.js
+++ b/src/getPackageExportSizes.js
@@ -5,12 +5,12 @@ const { getAllExports } = require('./utils/exports.utils')
 const InstallationUtils = require('./utils/installation.utils')
 const BuildUtils = require('./utils/build.utils')
 
-
 async function installPackage(packageString, options) {
   const { name: packageName, isLocal } = parsePackageString(packageString)
   const installPath = await InstallationUtils.preparePath(packageName)
 
   await InstallationUtils.installPackage(packageString, installPath, {
+    isLocal,
     client: options.client,
     limitConcurrency: options.limitConcurrency,
     networkConcurrency: options.networkConcurrency,

--- a/src/getPackageStats.js
+++ b/src/getPackageStats.js
@@ -38,10 +38,11 @@ function getPackageJSONDetails(packageName, installPath) {
 }
 
 async function getPackageStats(packageString, options = {}) {
-  const packageName = parsePackageString(packageString).name
+  const { name: packageName, isLocal } = parsePackageString(packageString)
   const installPath = await InstallationUtils.preparePath(packageName)
 
   await InstallationUtils.installPackage(packageString, installPath, {
+    isLocal,
     client: options.client,
     limitConcurrency: options.limitConcurrency,
     networkConcurrency: options.networkConcurrency,
@@ -67,7 +68,7 @@ async function getPackageStats(packageString, options = {}) {
         asset.name === 'main' && asset.type === (hasCSSAsset ? 'css' : 'js')
     )
 
-    InstallationUtils.cleaupPath(installPath)
+    // InstallationUtils.cleaupPath(installPath)
     return {
       ...pacakgeJSONDetails,
       ...builtDetails,

--- a/src/getPackageStats.js
+++ b/src/getPackageStats.js
@@ -68,7 +68,7 @@ async function getPackageStats(packageString, options = {}) {
         asset.name === 'main' && asset.type === (hasCSSAsset ? 'css' : 'js')
     )
 
-    // InstallationUtils.cleaupPath(installPath)
+    InstallationUtils.cleaupPath(installPath)
     return {
       ...pacakgeJSONDetails,
       ...builtDetails,

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -16,6 +16,17 @@ describe('getPackageStats', () => {
     expect(result.size).toEqual(425)
     done()
   })
+  test('dependencySizes', async done => {
+    const result = await getPackageStats(
+      path.resolve('./fixtures/node_modules/resolve-test')
+    )
+    expect(result.dependencySizes.length).toEqual(2)
+    expect(result.dependencySizes[0].name).toEqual(
+      'resolve-test/nested-folder/another-nested-folder'
+    )
+    expect(result.dependencySizes[1].name).toEqual('resolve-test')
+    done()
+  })
 })
 
 describe('getPackageExportSizes', () => {
@@ -23,7 +34,6 @@ describe('getPackageExportSizes', () => {
     const result = await getPackageExportSizes(
       path.resolve('./fixtures/node_modules/resolve-test')
     )
-    console.log(result)
     expect(result.assets.length).toEqual(4)
     expect(result.assets[0].path).toEqual('another-file-1.js')
     done()


### PR DESCRIPTION
The behaviour of `npm install <packageName>` and `npm install <localPath>` is inconsistent. More specially, `npm` when operating on a local directory, `npm` just links the folder in `node_modules` as opposed to installing it and all of its dependencies in a flatten structure. This is important because `package-build-stats` makes this assumption when navigating the dependency tree.

Rather than trying to determine the nature of the node_modules ad hoc, it would be better to operate on a consistent structure. We can achieve this with in`npm` by first packing the local package folder, and running `install` against the packed gzipped file. It's also worth noting this is how `yarn` installs local package folders (they don't do the linking).

With this commit, `dependencySizes` will be correctly be calculated.