### PR TITLE
Fix mjs rule not respecting overriden main fields

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -28,6 +28,8 @@ function makeWebpackConfig({ entry, externals }) {
   builtInNode['process'] = false
   builtInNode['Buffer'] = false
 
+  const mainFields = ['browser', 'module', 'main', 'style'];
+
   return {
     entry: entry,
     mode: 'production',
@@ -83,7 +85,7 @@ function makeWebpackConfig({ entry, externals }) {
         '.sass',
         '.scss',
       ],
-      mainFields: ['browser', 'module', 'main', 'style'],
+      mainFields,
     },
     module: {
       noParse: [/\.min\.js$/],
@@ -96,6 +98,7 @@ function makeWebpackConfig({ entry, externals }) {
         {
           type: 'javascript/auto',
           test: /\.mjs$/,
+          resolve: { mainFields },
           use: [],
         },
         {


### PR DESCRIPTION
Hiya :wave:

I found a little discrepancy in the `mjs` resolution in the `webpack.config.js` when using Bundlephobia.

What happened is that we migrated a package of ours, `@urql/core` to use `mjs` files and to support `package.json:exports` to be ready for Node v13 support. This package has a peer dependency on `graphql` which also provides `mjs` files.
We then discovered that the new version (which otherwise doesn't increase bundle size) shot up in the reported size: https://bundlephobia.com/result?p=@urql/core@1.10.3

It seems that the culprit is a missing configuration that prevents nested libraries with `mjs` files from being bundled correctly 😅 

This may not be the best choice by Webpack, but if we override `mainFields` we need to seemingly do the same for the `mjs` rule.

Edit: Here's an issue report on Webpack on this confusing behaviour. I haven't searched far and wide on whether this is intentional or not, but it seems that it'll have to be added for now 🤷‍♂ https://github.com/webpack/webpack/issues/6796