### PR TITLE
Add local build caveats: name, version, and main in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ const results = await getBuiltPackageStats('moment@2.24.0')
 
 ##### Building local packages (beta)
 
+Local package must have a `package.json` with at least `name`, `version`, and `main`.
+
 ```js
-const results = await getBuiltPackageStats('~/dev/my-npm-package') // must have a package.json
+const results = await getBuiltPackageStats('~/dev/my-npm-package') 
 ```
 
 #### Passing options to the build


### PR DESCRIPTION
I hit some issues trying this locally, so I figured I add some clarification to the docs. 

The error thrown when `version` was not included:
```
UnhandledPromiseRejectionWarning: Error: Cannot find module '/tmp/tmp-build/packages/build-object-export-zRf/node_modules/LOCAL_PACKAGE/package.json'
```

And no line-number was called out.