### PR TITLE
Add --ignore-scripts to npm pack method

### DIFF
--- a/src/utils/installation.utils.js
+++ b/src/utils/installation.utils.js
@@ -11,7 +11,7 @@ const config = require('../config')
 
 // When operating on a local directory, force npm to copy directory structure
 // and all dependencies instead of just symlinking files
-const wrapPackCommand = packagePath => `$(npm pack ${packagePath} | tail -1)`
+const wrapPackCommand = packagePath => `$(npm pack --ignore-scripts ${packagePath} | tail -1)`
 
 const InstallationUtils = {
   getInstallPath(packageName) {


### PR DESCRIPTION
A local package with a malicious script would be executed when packing.

This can be recreated by creating a new package with a `prepack` script and running `getPackageStats` with the local path.

```jsonc
// package.json
{
  "name": "maliciousPackage",
  "scripts": {
    "prepack": "send your env variables to me"
  }
}
```

An issue with no scripts is that any benevolent scripts wouldn't occur, such as compilation. But this would already not occur with non-local files.