### PR TITLE
Remove noParse rule from webpack config

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -89,7 +89,6 @@ function makeWebpackConfig({ entry, externals, debug }) {
       mainFields: ['browser', 'module', 'main', 'style'],
     },
     module: {
-      noParse: [/\.min\.js$/],
       rules: [
         {
           test: /\.css$/,


### PR DESCRIPTION
The noParse rule would break packages that have minified bundles with all es5 code except for import/export statements.

Fix #26