### PR TITLE
Upgrading vm2 to 3.9.5 to fix prototype pollution security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "svelte-loader": "^2.13.6",
     "terser": "^5.6.0",
     "terser-webpack-plugin": "^4.2.3",
-    "vm2": "^3.9.1",
+    "vm2": "^3.9.5",
     "vue-loader": "^15.9.3",
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.44.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11093,10 +11093,10 @@ vm-browserify@^1.0.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha1-eGQcSIuObKkadfUR56OzKobl3aA=
 
-vm2@^3.9.1:
-  version "3.9.2"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/vm2/-/vm2-3.9.2.tgz#a4085d2d88a808a1b3c06d5478c2db3222a9cc30"
-  integrity sha1-pAhdLYioCKGzwG1UeMLbMiKpzDA=
+vm2@^3.9.5:
+  version "3.9.5"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496"
+  integrity sha1-UogESGC0u6zkQxAfzTvdsqCqJJY=
 
 void-elements@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
### What?
Snyk has flagged vm2 3.9.2 as a vulnerable version for prototype pollution.

![image](https://user-images.githubusercontent.com/11498600/137686384-9b57ab97-f68c-4cfb-9fc7-183311c84afc.png)

Upgrading vm2 to 3.9.5 to fix it.