### PR TITLE
fix Sandbox Bypass vulnerability in vm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "svelte-loader": "^2.13.6",
     "terser": "^5.6.0",
     "terser-webpack-plugin": "^4.2.3",
-    "vm2": "^3.9.1",
+    "vm2": "^3.9.7",
     "vue-loader": "^15.9.3",
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.44.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,6 +1973,11 @@ acorn-walk@^6.0.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha1-Ejy487hMIXHx9/slJhWxx4prGow=
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^5.5.3:
   version "5.7.4"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
@@ -1992,6 +1997,11 @@ acorn@^8.0.4:
   version "8.0.5"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/acorn/-/acorn-8.0.5.tgz#a3bfb872a74a6a7f661bc81b9849d9cac12601b7"
   integrity sha1-o7+4cqdKan9mG8gbmEnZysEmAbc=
+
+acorn@^8.7.0:
+  version "8.7.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 after@0.8.2:
   version "0.8.2"
@@ -11093,10 +11103,13 @@ vm-browserify@^1.0.1:
   resolved "https://packages.atlassian.com/api/npm/npm-remote/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha1-eGQcSIuObKkadfUR56OzKobl3aA=
 
-vm2@^3.9.1:
-  version "3.9.2"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/vm2/-/vm2-3.9.2.tgz#a4085d2d88a808a1b3c06d5478c2db3222a9cc30"
-  integrity sha1-pAhdLYioCKGzwG1UeMLbMiKpzDA=
+vm2@^3.9.7:
+  version "3.9.7"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/vm2/-/vm2-3.9.7.tgz#bb87aa677c97c61e23a6cb6547e44e990517a6f6"
+  integrity sha512-g/GZ7V0Mlmch3eDVOATvAXr1GsJNg6kQ5PjvYy3HbJMCRn5slNbo/u73Uy7r5yUej1cRa3ZjtoVwcWSQuQ/fow==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 void-elements@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
vm2 with version < 3.9.6 has Sandbox Bypass vulnerability. Upgrading vm2 to 3.9.7
https://security.snyk.io/vuln/SNYK-JS-VM2-2309905