### PR TITLE
Add support for package shipped as ES2020+ JavaScript

### DIFF
--- a/fixtures/node_modules/resolve-test/entry-1.js
+++ b/fixtures/node_modules/resolve-test/entry-1.js
@@ -1,3 +1,7 @@
 
 export * from './another-file-1.js'
 export default function a() {}
+
+export class Foo {
+	static foo = 'foo';
+}

--- a/src/config/makeWebpackConfig.ts
+++ b/src/config/makeWebpackConfig.ts
@@ -160,6 +160,13 @@ export default function makeWebpackConfig({
                 ],
               },
             },
+            {
+              loader: 'esbuild-loader',
+              options: {
+                // Fail building package with anything more recent than es2019 as a target
+                target: 'es2019',
+              },
+            }
           ],
         },
 

--- a/tests/exports.utils.test.js
+++ b/tests/exports.utils.test.js
@@ -199,6 +199,7 @@ describe('getAllExports', () => {
       default:
         'node_modules/resolve-test/nested-folder/another-nested-folder/node_modules/dependency/dependency-entry-1.js',
       AClass: 'node_modules/resolve-test/another-file-1.js',
+      Foo: 'node_modules/resolve-test/entry-1.js',
       aVariable: 'node_modules/resolve-test/another-file-1.js',
       bFunction: 'node_modules/resolve-test/another-file-2.js',
       dependencyEntry:

--- a/tests/local.test.js
+++ b/tests/local.test.js
@@ -14,7 +14,7 @@ describe('getPackageStats', () => {
     const result = await getPackageStats(
       path.resolve('./fixtures/node_modules/resolve-test')
     )
-    expect(result.size).toEqual(434)
+    expect(result.size).toEqual(636)
   })
 
   test('dependencySizes', async () => {
@@ -24,7 +24,7 @@ describe('getPackageStats', () => {
 
     expect(result.dependencySizes.length).toEqual(2)
     expect(result.dependencySizes).toEqual(
-      expect.arrayContaining([{ name: 'resolve-test', approximateSize: 258 }])
+      expect.arrayContaining([{ name: 'resolve-test', approximateSize: 575 }])
     )
     expect(result.dependencySizes).toEqual(
       expect.arrayContaining([
@@ -42,7 +42,7 @@ describe('getPackageExportSizes', () => {
     const result = await getPackageExportSizes(
       path.resolve('./fixtures/node_modules/resolve-test')
     )
-    expect(result.assets.length).toEqual(4)
+    expect(result.assets.length).toEqual(5)
     expect(result.assets[0].path).toEqual('another-file-1.js')
   })
 })


### PR DESCRIPTION
Package shipping ES2020+ JavaScript fails to build with `Module parse failed: Unexpected token` errors. Some examples:

```
Module parse failed: Unexpected token (8:18)
File was processed with these loaders:
 * ./node_modules/shebang-loader/index.js
 * ./node_modules/string-replace-loader/index.js
You may need an additional loader to handle the result of these loaders.
| const cache = /* @__PURE__ */ new WeakMap();
| class Transition {
>   isTransitioning = false;
|   transitionEndHandler = null;
|   constructor(element) {

Module parse failed: Unexpected token (46:17)
File was processed with these loaders:
 * ./node_modules/shebang-loader/index.js
 * ./node_modules/string-replace-loader/index.js
You may need an additional loader to handle the result of these loaders.
| }
| class Base extends EventTarget {
>   static $isBase = true;
|   $parent = null;
|   $id;
```

Adding the `esbuild-loader` with the target set to `es2019` before the `shebang-loader` and `string-replace-loader` loaders fixes the errors.

I am not certain about all the side effects that this change could trigger, but the test suites are passing. 

Please let me know if this is not the correct solution for the above errors.