### PR TITLE
fix: write rspack output to unique temp dir and clean up after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-build-stats",
-  "version": "8.2.5",
+  "version": "8.2.6",
   "type": "module",
   "author": "Shubham Kanodia <shubham.kanodia10@gmail.com>",
   "repository": "https://github.com/pastelsky/package-build-stats",

--- a/src/config/makeRspackConfig.ts
+++ b/src/config/makeRspackConfig.ts
@@ -15,6 +15,7 @@ type MakeRspackConfigOptions = {
   debug?: boolean
   minify?: boolean
   entry: Entry
+  outputPath: string
 }
 
 export default function makeRspackConfig({
@@ -23,6 +24,7 @@ export default function makeRspackConfig({
   externals,
   debug: _debug,
   minify = true,
+  outputPath,
 }: MakeRspackConfigOptions): Configuration {
   const externalsRegex = makeExternalsRegex(externals.externalPackages)
   const isExternalRequest = (request: string) => {
@@ -176,6 +178,7 @@ export default function makeRspackConfig({
     },
     output: {
       filename: '[name].bundle.js',
+      path: outputPath,
     },
     externals: ({ request }, callback) =>
       isExternalRequest(request || '')

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import os from 'os'
+import config from '../config/config.js'
 import { Entry, rspack } from '@rspack/core'
 import isValidNPMName from 'is-valid-npm-name'
 import { gzipSync } from 'zlib'
@@ -218,7 +218,7 @@ const BuildUtils = {
     externals,
     options,
   }: BuildPackageArgs) {
-    const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-build-'))
+    const outputPath = fs.mkdtempSync(path.join(config.tmp, 'pkg-build-'))
     let entry: any = {}
 
     if (options.splitCustomImports) {

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -218,12 +218,11 @@ const BuildUtils = {
     externals,
     options,
   }: BuildPackageArgs) {
-    const outputPath = fs.mkdtempSync(path.join(config.tmp, 'pkg-build-'))
+    const outputPath = config.tmp
     let entry: any = {}
 
     if (options.splitCustomImports) {
       if (!options.customImports || !options.customImports.length) {
-        fs.rmSync(outputPath, { recursive: true, force: true })
         return { assets: [] }
       }
       options.customImports.forEach(importt => {
@@ -249,7 +248,6 @@ const BuildUtils = {
       outputPath,
     })
 
-    try {
     const jsonStatsStartTime = performance.now()
     let jsonStats = stats.toJson({
       assets: true,
@@ -363,9 +361,6 @@ const BuildUtils = {
         assets: assetStats || [],
         ...dependencySizeResults,
       }
-    }
-    } finally {
-      fs.rmSync(outputPath, { recursive: true, force: true })
     }
   },
   async buildPackageIgnoringMissingDeps({

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import os from 'os'
 import { Entry, rspack } from '@rspack/core'
 import isValidNPMName from 'is-valid-npm-name'
 import { gzipSync } from 'zlib'
@@ -28,6 +29,7 @@ type CompilePackageArgs = {
   entry: Entry
   debug?: boolean
   minify?: boolean
+  outputPath: string
 }
 
 type CompilePackageReturn = {
@@ -133,6 +135,7 @@ const BuildUtils = {
     externals,
     debug,
     minify,
+    outputPath,
   }: CompilePackageArgs) {
     const startTime = performance.now()
 
@@ -142,6 +145,7 @@ const BuildUtils = {
       externals,
       debug,
       minify,
+      outputPath,
     })
 
     const compiler = rspack(options)
@@ -214,10 +218,12 @@ const BuildUtils = {
     externals,
     options,
   }: BuildPackageArgs) {
+    const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-build-'))
     let entry: any = {}
 
     if (options.splitCustomImports) {
       if (!options.customImports || !options.customImports.length) {
+        fs.rmSync(outputPath, { recursive: true, force: true })
         return { assets: [] }
       }
       options.customImports.forEach(importt => {
@@ -240,8 +246,10 @@ const BuildUtils = {
       externals,
       debug: options.debug,
       minify: options.minify,
+      outputPath,
     })
 
+    try {
     const jsonStatsStartTime = performance.now()
     let jsonStats = stats.toJson({
       assets: true,
@@ -300,7 +308,7 @@ const BuildUtils = {
       }
     } else {
       const getAssetStats = async (asset: RspackStatsAsset) => {
-        const bundle = path.join(process.cwd(), 'dist', asset.name)
+        const bundle = path.join(outputPath, asset.name)
         const bundleContents = await fs.promises.readFile(bundle)
 
         const gzip = gzipSync(bundleContents, {}).length
@@ -355,6 +363,9 @@ const BuildUtils = {
         assets: assetStats || [],
         ...dependencySizeResults,
       }
+    }
+    } finally {
+      fs.rmSync(outputPath, { recursive: true, force: true })
     }
   },
   async buildPackageIgnoringMissingDeps({


### PR DESCRIPTION
## Problem

rspack had no `output.path` configured, so it defaulted to `process.cwd()/dist`. Every package build request wrote bundle files there and **never cleaned them up**.

In production this caused unbounded disk accumulation:
- **516,182 files** in `/var/www/bundlephobia/dist/`
- **17GB** consumed by build artifacts
- Disk was hitting 100% every 30 minutes, triggering OOM kills of the Node process, cascading into full server crashes

## Root Cause

Two issues:
1. `makeRspackConfig` had no `output.path` → rspack defaulted to `cwd/dist`
2. `build.utils.ts` read bundles from hardcoded `path.join(process.cwd(), 'dist', asset.name)` and never deleted them after reading

## Fix

- **`makeRspackConfig.ts`**: Accept `outputPath` option and pass it to `output.path`
- **`build.utils.ts`**: Create a unique temp dir per build via `fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-build-'))`, thread it through `compilePackage` → `makeRspackConfig`, read bundle sizes from it, then delete the entire dir in a `finally` block — covering both success and error paths

## Result

Every build now writes to e.g. `/tmp/pkg-build-xK3j2f/`, reads the sizes, and immediately cleans up. Zero accumulation in `dist/`.