### PR TITLE
fix: name Rspack asset modules as bundles

### DIFF
--- a/src/config/makeRspackConfig.ts
+++ b/src/config/makeRspackConfig.ts
@@ -178,6 +178,7 @@ export default function makeRspackConfig({
     },
     output: {
       filename: '[name].bundle.js',
+      assetModuleFilename: '[name].[contenthash:8].bundle[ext]',
       path: outputPath,
     },
     externals: ({ request }, callback) =>

--- a/tests/fast/makeRspackConfig.test.ts
+++ b/tests/fast/makeRspackConfig.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+
+import makeRspackConfig from '../../src/config/makeRspackConfig.js'
+
+describe('makeRspackConfig', () => {
+  test('uses bundle naming for emitted asset modules', () => {
+    const config = makeRspackConfig({
+      packageName: 'demo-package',
+      externals: {
+        externalPackages: [],
+        externalBuiltIns: [],
+      },
+      entry: {
+        main: '/tmp/demo-package/index.js',
+      },
+      outputPath: '/tmp/demo-package/dist',
+    })
+
+    expect(config.output).toMatchObject({
+      filename: '[name].bundle.js',
+      assetModuleFilename: '[name].[contenthash:8].bundle[ext]',
+      path: '/tmp/demo-package/dist',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Configure Rspack asset modules to use the existing `.bundle.` filename convention.
- Keep a content hash in asset filenames to avoid collisions between duplicate asset basenames.
- Add a fast config test for the asset module filename contract.

## Context
`package-build-stats` already parses non-runtime emitted assets with the `/(.+?)\.bundle\.(.+)$/` convention. Rspack asset modules can otherwise emit hash-only filenames such as `caaf4c9c800939e7.js`, which do not match that convention and can surface as `Found an asset without the .bundle suffix`.

## Validation
- `corepack yarn install --immutable`
- `corepack yarn vitest run tests/fast/makeRspackConfig.test.ts`
- `corepack yarn check`
- `corepack yarn test`
- Local Rspack smoke with a package that emits a JS asset module: default output used a hash-only filename; with this config it used the `.bundle.` asset filename convention.