### PR TITLE
Add automated Changesets releases

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,22 @@
+# Changesets
+
+Every pull request that changes the published package should include a changeset:
+
+```sh
+yarn changeset
+```
+
+Choose `patch`, `minor`, or `major` using semantic-versioning rules and write a
+short user-facing summary. Documentation and CI-only changes do not need one.
+
+After changes land on `master`, the release workflow maintains a "Version
+Packages" pull request. Merging that pull request publishes the new version to
+npm, creates the git tag, and creates a GitHub release.
+
+Publishing uses npm trusted publishing (OIDC), not a long-lived npm token. The
+trusted publisher for `package-build-stats` must point at:
+
+- GitHub owner: `pastelsky`
+- Repository: `package-build-stats`
+- Workflow: `release.yml`
+- Permission: `npm publish`

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "master",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    name: Version or publish
+    if: github.repository == 'pastelsky/package-build-stats'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: corepack yarn install --immutable
+
+      - name: Validate package
+        run: |
+          corepack yarn check
+          corepack yarn test
+          corepack yarn build
+
+      - name: Create release pull request or publish
+        uses: changesets/action@v1
+        with:
+          version: corepack yarn version-packages
+          publish: corepack yarn release
+          commit: 'Release: version package'
+          title: 'Release: version package'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,3 @@
 nodeLinker: node-modules
 nmHoistingLimits: workspaces
+npmRegistryServer: 'https://registry.npmjs.org'

--- a/package.json
+++ b/package.json
@@ -34,13 +34,16 @@
     "test:watch": "vitest tests/fast",
     "test:coverage": "vitest run --coverage tests/fast",
     "test:ci": "yarn check && yarn test && yarn test:coverage",
+    "changeset": "changeset",
+    "version-packages": "changeset version",
+    "release": "changeset publish",
     "compare": "tsx scripts/index.ts",
     "compare:list": "tsx scripts/index.ts list",
     "compare:test": "tsx scripts/index.ts test",
     "compare:top": "tsx scripts/index.ts top",
     "compare:advanced": "tsx scripts/index.ts compare",
     "perf:test": "tsx scripts/performance-test.ts",
-    "prepack": "rm -rf build && yarn check && yarn build && yarn format"
+    "prepack": "rm -rf build && yarn check && yarn build"
   },
   "prettier": {
     "semi": false,
@@ -51,6 +54,7 @@
     "package-stats": "./bin/cli.js"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.31.1",
     "@rsdoctor/rspack-plugin": "^1.3.8",
     "@types/autoprefixer": "^9.7.2",
     "@types/debug": "^4.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@ampproject/remapping@npm:^2.2.1":
   version: 2.3.0
-  resolution: "@ampproject/remapping@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40ampproject%2Fremapping%2F-%2Fremapping-2.3.0.tgz"
+  resolution: "@ampproject/remapping@npm:2.3.0"
   dependencies:
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
@@ -17,7 +17,7 @@ __metadata:
 
 "@babel/code-frame@npm:7.26.2":
   version: 7.26.2
-  resolution: "@babel/code-frame@npm:7.26.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fcode-frame%2F-%2Fcode-frame-7.26.2.tgz"
+  resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
     "@babel/helper-validator-identifier": "npm:^7.25.9"
     js-tokens: "npm:^4.0.0"
@@ -28,7 +28,7 @@ __metadata:
 
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/code-frame@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fcode-frame%2F-%2Fcode-frame-7.28.6.tgz"
+  resolution: "@babel/code-frame@npm:7.28.6"
   dependencies:
     "@babel/helper-validator-identifier": "npm:^7.28.5"
     js-tokens: "npm:^4.0.0"
@@ -39,14 +39,14 @@ __metadata:
 
 "@babel/compat-data@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/compat-data@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fcompat-data%2F-%2Fcompat-data-7.28.6.tgz"
+  resolution: "@babel/compat-data@npm:7.28.6"
   checksum: 10c0/2d047431041281eaf33e9943d1a269d3374dbc9b498cafe6a18f5ee9aee7bb96f7f6cac0304eab4d13c41fc4db00fe4ca16c7aa44469ca6a211b8b6343b78fc4
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.28.5":
   version: 7.28.6
-  resolution: "@babel/core@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fcore%2F-%2Fcore-7.28.6.tgz"
+  resolution: "@babel/core@npm:7.28.6"
   dependencies:
     "@babel/code-frame": "npm:^7.28.6"
     "@babel/generator": "npm:^7.28.6"
@@ -69,7 +69,7 @@ __metadata:
 
 "@babel/generator@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/generator@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fgenerator%2F-%2Fgenerator-7.28.6.tgz"
+  resolution: "@babel/generator@npm:7.28.6"
   dependencies:
     "@babel/parser": "npm:^7.28.6"
     "@babel/types": "npm:^7.28.6"
@@ -82,7 +82,7 @@ __metadata:
 
 "@babel/helper-compilation-targets@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/helper-compilation-targets@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-compilation-targets%2F-%2Fhelper-compilation-targets-7.28.6.tgz"
+  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
   dependencies:
     "@babel/compat-data": "npm:^7.28.6"
     "@babel/helper-validator-option": "npm:^7.27.1"
@@ -95,14 +95,14 @@ __metadata:
 
 "@babel/helper-globals@npm:^7.28.0":
   version: 7.28.0
-  resolution: "@babel/helper-globals@npm:7.28.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-globals%2F-%2Fhelper-globals-7.28.0.tgz"
+  resolution: "@babel/helper-globals@npm:7.28.0"
   checksum: 10c0/5a0cd0c0e8c764b5f27f2095e4243e8af6fa145daea2b41b53c0c1414fe6ff139e3640f4e2207ae2b3d2153a1abd346f901c26c290ee7cb3881dd922d4ee9232
   languageName: node
   linkType: hard
 
 "@babel/helper-module-imports@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/helper-module-imports@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-module-imports%2F-%2Fhelper-module-imports-7.28.6.tgz"
+  resolution: "@babel/helper-module-imports@npm:7.28.6"
   dependencies:
     "@babel/traverse": "npm:^7.28.6"
     "@babel/types": "npm:^7.28.6"
@@ -112,7 +112,7 @@ __metadata:
 
 "@babel/helper-module-transforms@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/helper-module-transforms@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-module-transforms%2F-%2Fhelper-module-transforms-7.28.6.tgz"
+  resolution: "@babel/helper-module-transforms@npm:7.28.6"
   dependencies:
     "@babel/helper-module-imports": "npm:^7.28.6"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
@@ -125,28 +125,28 @@ __metadata:
 
 "@babel/helper-string-parser@npm:^7.27.1":
   version: 7.27.1
-  resolution: "@babel/helper-string-parser@npm:7.27.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-string-parser%2F-%2Fhelper-string-parser-7.27.1.tgz"
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
   checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
   languageName: node
   linkType: hard
 
 "@babel/helper-validator-identifier@npm:^7.25.9, @babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
-  resolution: "@babel/helper-validator-identifier@npm:7.28.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-validator-identifier%2F-%2Fhelper-validator-identifier-7.28.5.tgz"
+  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
   languageName: node
   linkType: hard
 
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
-  resolution: "@babel/helper-validator-option@npm:7.27.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelper-validator-option%2F-%2Fhelper-validator-option-7.27.1.tgz"
+  resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
   languageName: node
   linkType: hard
 
 "@babel/helpers@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/helpers@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fhelpers%2F-%2Fhelpers-7.28.6.tgz"
+  resolution: "@babel/helpers@npm:7.28.6"
   dependencies:
     "@babel/template": "npm:^7.28.6"
     "@babel/types": "npm:^7.28.6"
@@ -156,7 +156,7 @@ __metadata:
 
 "@babel/parser@npm:^7.28.5, @babel/parser@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/parser@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fparser%2F-%2Fparser-7.28.6.tgz"
+  resolution: "@babel/parser@npm:7.28.6"
   dependencies:
     "@babel/types": "npm:^7.28.6"
   bin:
@@ -167,7 +167,7 @@ __metadata:
 
 "@babel/parser@npm:^7.6.0, @babel/parser@npm:^7.9.6":
   version: 7.29.0
-  resolution: "@babel/parser@npm:7.29.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fparser%2F-%2Fparser-7.29.0.tgz"
+  resolution: "@babel/parser@npm:7.29.0"
   dependencies:
     "@babel/types": "npm:^7.29.0"
   bin:
@@ -178,14 +178,14 @@ __metadata:
 
 "@babel/runtime@npm:^7.5.5":
   version: 7.29.7
-  resolution: "@babel/runtime@npm:7.29.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fruntime%2F-%2Fruntime-7.29.7.tgz"
+  resolution: "@babel/runtime@npm:7.29.7"
   checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
   languageName: node
   linkType: hard
 
 "@babel/template@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/template@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Ftemplate%2F-%2Ftemplate-7.28.6.tgz"
+  resolution: "@babel/template@npm:7.28.6"
   dependencies:
     "@babel/code-frame": "npm:^7.28.6"
     "@babel/parser": "npm:^7.28.6"
@@ -196,7 +196,7 @@ __metadata:
 
 "@babel/traverse@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/traverse@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Ftraverse%2F-%2Ftraverse-7.28.6.tgz"
+  resolution: "@babel/traverse@npm:7.28.6"
   dependencies:
     "@babel/code-frame": "npm:^7.28.6"
     "@babel/generator": "npm:^7.28.6"
@@ -211,7 +211,7 @@ __metadata:
 
 "@babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6":
   version: 7.28.6
-  resolution: "@babel/types@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Ftypes%2F-%2Ftypes-7.28.6.tgz"
+  resolution: "@babel/types@npm:7.28.6"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
@@ -221,7 +221,7 @@ __metadata:
 
 "@babel/types@npm:^7.29.0, @babel/types@npm:^7.6.1, @babel/types@npm:^7.9.6":
   version: 7.29.0
-  resolution: "@babel/types@npm:7.29.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Ftypes%2F-%2Ftypes-7.29.0.tgz"
+  resolution: "@babel/types@npm:7.29.0"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
@@ -231,14 +231,14 @@ __metadata:
 
 "@bcoe/v8-coverage@npm:^1.0.2":
   version: 1.0.2
-  resolution: "@bcoe/v8-coverage@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40bcoe%2Fv8-coverage%2F-%2Fv8-coverage-1.0.2.tgz"
+  resolution: "@bcoe/v8-coverage@npm:1.0.2"
   checksum: 10c0/1eb1dc93cc17fb7abdcef21a6e7b867d6aa99a7ec88ec8207402b23d9083ab22a8011213f04b2cf26d535f1d22dc26139b7929e6c2134c254bd1e14ba5e678c3
   languageName: node
   linkType: hard
 
 "@changesets/apply-release-plan@npm:^7.1.1":
   version: 7.1.1
-  resolution: "@changesets/apply-release-plan@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fapply-release-plan%2F-%2Fapply-release-plan-7.1.1.tgz"
+  resolution: "@changesets/apply-release-plan@npm:7.1.1"
   dependencies:
     "@changesets/config": "npm:^3.1.4"
     "@changesets/get-version-range-type": "npm:^0.4.0"
@@ -259,7 +259,7 @@ __metadata:
 
 "@changesets/assemble-release-plan@npm:^6.0.10":
   version: 6.0.10
-  resolution: "@changesets/assemble-release-plan@npm:6.0.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fassemble-release-plan%2F-%2Fassemble-release-plan-6.0.10.tgz"
+  resolution: "@changesets/assemble-release-plan@npm:6.0.10"
   dependencies:
     "@changesets/errors": "npm:^0.2.0"
     "@changesets/get-dependents-graph": "npm:^2.1.4"
@@ -273,7 +273,7 @@ __metadata:
 
 "@changesets/changelog-git@npm:^0.2.1":
   version: 0.2.1
-  resolution: "@changesets/changelog-git@npm:0.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fchangelog-git%2F-%2Fchangelog-git-0.2.1.tgz"
+  resolution: "@changesets/changelog-git@npm:0.2.1"
   dependencies:
     "@changesets/types": "npm:^6.1.0"
   checksum: 10c0/6a6fb315ffb2266fcb8f32ae9a60ccdb5436e52350a2f53beacf9822d3355f9052aba5001a718e12af472b4a8fabd69b408d0b11c02ac909ba7a183d27a9f7fd
@@ -282,7 +282,7 @@ __metadata:
 
 "@changesets/cli@npm:^2.31.1":
   version: 2.31.1
-  resolution: "@changesets/cli@npm:2.31.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fcli%2F-%2Fcli-2.31.1.tgz"
+  resolution: "@changesets/cli@npm:2.31.1"
   dependencies:
     "@changesets/apply-release-plan": "npm:^7.1.1"
     "@changesets/assemble-release-plan": "npm:^6.0.10"
@@ -318,7 +318,7 @@ __metadata:
 
 "@changesets/config@npm:^3.1.4":
   version: 3.1.4
-  resolution: "@changesets/config@npm:3.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fconfig%2F-%2Fconfig-3.1.4.tgz"
+  resolution: "@changesets/config@npm:3.1.4"
   dependencies:
     "@changesets/errors": "npm:^0.2.0"
     "@changesets/get-dependents-graph": "npm:^2.1.4"
@@ -334,7 +334,7 @@ __metadata:
 
 "@changesets/errors@npm:^0.2.0":
   version: 0.2.0
-  resolution: "@changesets/errors@npm:0.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Ferrors%2F-%2Ferrors-0.2.0.tgz"
+  resolution: "@changesets/errors@npm:0.2.0"
   dependencies:
     extendable-error: "npm:^0.1.5"
   checksum: 10c0/f2757c752ab04e9733b0dfd7903f1caf873f9e603794c4d9ea2294af4f937c73d07273c24be864ad0c30b6a98424360d5b96a6eab14f97f3cf2cbfd3763b95c1
@@ -343,7 +343,7 @@ __metadata:
 
 "@changesets/get-dependents-graph@npm:^2.1.4":
   version: 2.1.4
-  resolution: "@changesets/get-dependents-graph@npm:2.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fget-dependents-graph%2F-%2Fget-dependents-graph-2.1.4.tgz"
+  resolution: "@changesets/get-dependents-graph@npm:2.1.4"
   dependencies:
     "@changesets/types": "npm:^6.1.0"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -355,7 +355,7 @@ __metadata:
 
 "@changesets/get-release-plan@npm:^4.0.16":
   version: 4.0.16
-  resolution: "@changesets/get-release-plan@npm:4.0.16::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fget-release-plan%2F-%2Fget-release-plan-4.0.16.tgz"
+  resolution: "@changesets/get-release-plan@npm:4.0.16"
   dependencies:
     "@changesets/assemble-release-plan": "npm:^6.0.10"
     "@changesets/config": "npm:^3.1.4"
@@ -369,14 +369,14 @@ __metadata:
 
 "@changesets/get-version-range-type@npm:^0.4.0":
   version: 0.4.0
-  resolution: "@changesets/get-version-range-type@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fget-version-range-type%2F-%2Fget-version-range-type-0.4.0.tgz"
+  resolution: "@changesets/get-version-range-type@npm:0.4.0"
   checksum: 10c0/e466208c8383489a383f37958d8b5b9aed38539f9287b47fe155a2e8855973f6960fb1724a1ee33b11580d65e1011059045ee654e8ef51e4783017d8989c9d3f
   languageName: node
   linkType: hard
 
 "@changesets/git@npm:^3.0.4":
   version: 3.0.4
-  resolution: "@changesets/git@npm:3.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fgit%2F-%2Fgit-3.0.4.tgz"
+  resolution: "@changesets/git@npm:3.0.4"
   dependencies:
     "@changesets/errors": "npm:^0.2.0"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -389,7 +389,7 @@ __metadata:
 
 "@changesets/logger@npm:^0.1.1":
   version: 0.1.1
-  resolution: "@changesets/logger@npm:0.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Flogger%2F-%2Flogger-0.1.1.tgz"
+  resolution: "@changesets/logger@npm:0.1.1"
   dependencies:
     picocolors: "npm:^1.1.0"
   checksum: 10c0/a0933b5bd4d99e10730b22612dc1bdfd25b8804c5b48f8cada050bf5c7a89b2ae9a61687f846a5e9e5d379a95b59fef795c8d5d91e49a251f8da2be76133f83f
@@ -398,7 +398,7 @@ __metadata:
 
 "@changesets/parse@npm:^0.4.3":
   version: 0.4.3
-  resolution: "@changesets/parse@npm:0.4.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fparse%2F-%2Fparse-0.4.3.tgz"
+  resolution: "@changesets/parse@npm:0.4.3"
   dependencies:
     "@changesets/types": "npm:^6.1.0"
     js-yaml: "npm:^4.1.1"
@@ -408,7 +408,7 @@ __metadata:
 
 "@changesets/pre@npm:^2.0.2":
   version: 2.0.2
-  resolution: "@changesets/pre@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fpre%2F-%2Fpre-2.0.2.tgz"
+  resolution: "@changesets/pre@npm:2.0.2"
   dependencies:
     "@changesets/errors": "npm:^0.2.0"
     "@changesets/types": "npm:^6.1.0"
@@ -420,7 +420,7 @@ __metadata:
 
 "@changesets/read@npm:^0.6.7":
   version: 0.6.7
-  resolution: "@changesets/read@npm:0.6.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fread%2F-%2Fread-0.6.7.tgz"
+  resolution: "@changesets/read@npm:0.6.7"
   dependencies:
     "@changesets/git": "npm:^3.0.4"
     "@changesets/logger": "npm:^0.1.1"
@@ -435,7 +435,7 @@ __metadata:
 
 "@changesets/should-skip-package@npm:^0.1.2":
   version: 0.1.2
-  resolution: "@changesets/should-skip-package@npm:0.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fshould-skip-package%2F-%2Fshould-skip-package-0.1.2.tgz"
+  resolution: "@changesets/should-skip-package@npm:0.1.2"
   dependencies:
     "@changesets/types": "npm:^6.1.0"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -445,21 +445,21 @@ __metadata:
 
 "@changesets/types@npm:^4.0.1":
   version: 4.1.0
-  resolution: "@changesets/types@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Ftypes%2F-%2Ftypes-4.1.0.tgz"
+  resolution: "@changesets/types@npm:4.1.0"
   checksum: 10c0/a372ad21f6a1e0d4ce6c19573c1ca269eef1ad53c26751ad9515a24f003e7c49dcd859dbb1fedb6badaf7be956c1559e8798304039e0ec0da2d9a68583f13464
   languageName: node
   linkType: hard
 
 "@changesets/types@npm:^6.1.0":
   version: 6.1.0
-  resolution: "@changesets/types@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Ftypes%2F-%2Ftypes-6.1.0.tgz"
+  resolution: "@changesets/types@npm:6.1.0"
   checksum: 10c0/b4cea3a4465d1eaf0bbd7be1e404aca5a055a61d4cc72aadcb73bbbda1670b4022736b8d3052616cbf1f451afa0637545d077697f4b923236539af9cd5abce6c
   languageName: node
   linkType: hard
 
 "@changesets/write@npm:^0.4.0":
   version: 0.4.0
-  resolution: "@changesets/write@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fwrite%2F-%2Fwrite-0.4.0.tgz"
+  resolution: "@changesets/write@npm:0.4.0"
   dependencies:
     "@changesets/types": "npm:^6.1.0"
     fs-extra: "npm:^7.0.1"
@@ -471,7 +471,7 @@ __metadata:
 
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
-  resolution: "@cspotcode/source-map-support@npm:0.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40cspotcode%2Fsource-map-support%2F-%2Fsource-map-support-0.8.1.tgz"
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
   dependencies:
     "@jridgewell/trace-mapping": "npm:0.3.9"
   checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
@@ -480,7 +480,7 @@ __metadata:
 
 "@emnapi/core@npm:^1.5.0, @emnapi/core@npm:^1.7.1":
   version: 1.8.1
-  resolution: "@emnapi/core@npm:1.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40emnapi%2Fcore%2F-%2Fcore-1.8.1.tgz"
+  resolution: "@emnapi/core@npm:1.8.1"
   dependencies:
     "@emnapi/wasi-threads": "npm:1.1.0"
     tslib: "npm:^2.4.0"
@@ -490,7 +490,7 @@ __metadata:
 
 "@emnapi/runtime@npm:^1.5.0, @emnapi/runtime@npm:^1.7.1":
   version: 1.8.1
-  resolution: "@emnapi/runtime@npm:1.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40emnapi%2Fruntime%2F-%2Fruntime-1.8.1.tgz"
+  resolution: "@emnapi/runtime@npm:1.8.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
@@ -499,7 +499,7 @@ __metadata:
 
 "@emnapi/wasi-threads@npm:1.1.0":
   version: 1.1.0
-  resolution: "@emnapi/wasi-threads@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40emnapi%2Fwasi-threads%2F-%2Fwasi-threads-1.1.0.tgz"
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
@@ -508,399 +508,399 @@ __metadata:
 
 "@esbuild/aix-ppc64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/aix-ppc64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Faix-ppc64%2F-%2Faix-ppc64-0.25.12.tgz"
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
 "@esbuild/aix-ppc64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/aix-ppc64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Faix-ppc64%2F-%2Faix-ppc64-0.27.2.tgz"
+  resolution: "@esbuild/aix-ppc64@npm:0.27.2"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
 "@esbuild/android-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/android-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fandroid-arm64%2F-%2Fandroid-arm64-0.25.12.tgz"
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/android-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/android-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fandroid-arm64%2F-%2Fandroid-arm64-0.27.2.tgz"
+  resolution: "@esbuild/android-arm64@npm:0.27.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/android-arm@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/android-arm@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fandroid-arm%2F-%2Fandroid-arm-0.25.12.tgz"
+  resolution: "@esbuild/android-arm@npm:0.25.12"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
 "@esbuild/android-arm@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/android-arm@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fandroid-arm%2F-%2Fandroid-arm-0.27.2.tgz"
+  resolution: "@esbuild/android-arm@npm:0.27.2"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
 "@esbuild/android-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/android-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fandroid-x64%2F-%2Fandroid-x64-0.25.12.tgz"
+  resolution: "@esbuild/android-x64@npm:0.25.12"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/android-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/android-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fandroid-x64%2F-%2Fandroid-x64-0.27.2.tgz"
+  resolution: "@esbuild/android-x64@npm:0.27.2"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/darwin-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/darwin-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fdarwin-arm64%2F-%2Fdarwin-arm64-0.25.12.tgz"
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/darwin-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/darwin-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fdarwin-arm64%2F-%2Fdarwin-arm64-0.27.2.tgz"
+  resolution: "@esbuild/darwin-arm64@npm:0.27.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/darwin-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/darwin-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fdarwin-x64%2F-%2Fdarwin-x64-0.25.12.tgz"
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/darwin-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/darwin-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fdarwin-x64%2F-%2Fdarwin-x64-0.27.2.tgz"
+  resolution: "@esbuild/darwin-x64@npm:0.27.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/freebsd-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Ffreebsd-arm64%2F-%2Ffreebsd-arm64-0.25.12.tgz"
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/freebsd-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Ffreebsd-arm64%2F-%2Ffreebsd-arm64-0.27.2.tgz"
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.2"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/freebsd-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/freebsd-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Ffreebsd-x64%2F-%2Ffreebsd-x64-0.25.12.tgz"
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/freebsd-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/freebsd-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Ffreebsd-x64%2F-%2Ffreebsd-x64-0.27.2.tgz"
+  resolution: "@esbuild/freebsd-x64@npm:0.27.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-arm64%2F-%2Flinux-arm64-0.25.12.tgz"
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-arm64%2F-%2Flinux-arm64-0.27.2.tgz"
+  resolution: "@esbuild/linux-arm64@npm:0.27.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-arm@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-arm@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-arm%2F-%2Flinux-arm-0.25.12.tgz"
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@esbuild/linux-arm@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-arm@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-arm%2F-%2Flinux-arm-0.27.2.tgz"
+  resolution: "@esbuild/linux-arm@npm:0.27.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@esbuild/linux-ia32@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-ia32@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-ia32%2F-%2Flinux-ia32-0.25.12.tgz"
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
 "@esbuild/linux-ia32@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-ia32@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-ia32%2F-%2Flinux-ia32-0.27.2.tgz"
+  resolution: "@esbuild/linux-ia32@npm:0.27.2"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
 "@esbuild/linux-loong64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-loong64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-loong64%2F-%2Flinux-loong64-0.25.12.tgz"
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-loong64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-loong64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-loong64%2F-%2Flinux-loong64-0.27.2.tgz"
+  resolution: "@esbuild/linux-loong64@npm:0.27.2"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-mips64el@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-mips64el@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-mips64el%2F-%2Flinux-mips64el-0.25.12.tgz"
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
 "@esbuild/linux-mips64el@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-mips64el@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-mips64el%2F-%2Flinux-mips64el-0.27.2.tgz"
+  resolution: "@esbuild/linux-mips64el@npm:0.27.2"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
 "@esbuild/linux-ppc64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-ppc64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-ppc64%2F-%2Flinux-ppc64-0.25.12.tgz"
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-ppc64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-ppc64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-ppc64%2F-%2Flinux-ppc64-0.27.2.tgz"
+  resolution: "@esbuild/linux-ppc64@npm:0.27.2"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-riscv64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-riscv64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-riscv64%2F-%2Flinux-riscv64-0.25.12.tgz"
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-riscv64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-riscv64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-riscv64%2F-%2Flinux-riscv64-0.27.2.tgz"
+  resolution: "@esbuild/linux-riscv64@npm:0.27.2"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-s390x@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-s390x@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-s390x%2F-%2Flinux-s390x-0.25.12.tgz"
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
 "@esbuild/linux-s390x@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-s390x@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-s390x%2F-%2Flinux-s390x-0.27.2.tgz"
+  resolution: "@esbuild/linux-s390x@npm:0.27.2"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
 "@esbuild/linux-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/linux-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-x64%2F-%2Flinux-x64-0.25.12.tgz"
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/linux-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/linux-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Flinux-x64%2F-%2Flinux-x64-0.27.2.tgz"
+  resolution: "@esbuild/linux-x64@npm:0.27.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/netbsd-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fnetbsd-arm64%2F-%2Fnetbsd-arm64-0.25.12.tgz"
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/netbsd-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fnetbsd-arm64%2F-%2Fnetbsd-arm64-0.27.2.tgz"
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.2"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/netbsd-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/netbsd-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fnetbsd-x64%2F-%2Fnetbsd-x64-0.25.12.tgz"
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/netbsd-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/netbsd-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fnetbsd-x64%2F-%2Fnetbsd-x64-0.27.2.tgz"
+  resolution: "@esbuild/netbsd-x64@npm:0.27.2"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/openbsd-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fopenbsd-arm64%2F-%2Fopenbsd-arm64-0.25.12.tgz"
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/openbsd-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fopenbsd-arm64%2F-%2Fopenbsd-arm64-0.27.2.tgz"
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.2"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/openbsd-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/openbsd-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fopenbsd-x64%2F-%2Fopenbsd-x64-0.25.12.tgz"
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/openbsd-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/openbsd-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fopenbsd-x64%2F-%2Fopenbsd-x64-0.27.2.tgz"
+  resolution: "@esbuild/openbsd-x64@npm:0.27.2"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/openharmony-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/openharmony-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fopenharmony-arm64%2F-%2Fopenharmony-arm64-0.25.12.tgz"
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/openharmony-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fopenharmony-arm64%2F-%2Fopenharmony-arm64-0.27.2.tgz"
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.2"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/sunos-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/sunos-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fsunos-x64%2F-%2Fsunos-x64-0.25.12.tgz"
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/sunos-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/sunos-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fsunos-x64%2F-%2Fsunos-x64-0.27.2.tgz"
+  resolution: "@esbuild/sunos-x64@npm:0.27.2"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/win32-arm64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/win32-arm64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fwin32-arm64%2F-%2Fwin32-arm64-0.25.12.tgz"
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/win32-arm64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/win32-arm64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fwin32-arm64%2F-%2Fwin32-arm64-0.27.2.tgz"
+  resolution: "@esbuild/win32-arm64@npm:0.27.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@esbuild/win32-ia32@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/win32-ia32@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fwin32-ia32%2F-%2Fwin32-ia32-0.25.12.tgz"
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@esbuild/win32-ia32@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/win32-ia32@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fwin32-ia32%2F-%2Fwin32-ia32-0.27.2.tgz"
+  resolution: "@esbuild/win32-ia32@npm:0.27.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@esbuild/win32-x64@npm:0.25.12":
   version: 0.25.12
-  resolution: "@esbuild/win32-x64@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fwin32-x64%2F-%2Fwin32-x64-0.25.12.tgz"
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@esbuild/win32-x64@npm:0.27.2":
   version: 0.27.2
-  resolution: "@esbuild/win32-x64@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40esbuild%2Fwin32-x64%2F-%2Fwin32-x64-0.27.2.tgz"
+  resolution: "@esbuild/win32-x64@npm:0.27.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@fastify/busboy@npm:^3.0.0":
   version: 3.2.0
-  resolution: "@fastify/busboy@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40fastify%2Fbusboy%2F-%2Fbusboy-3.2.0.tgz"
+  resolution: "@fastify/busboy@npm:3.2.0"
   checksum: 10c0/3e4fb00a27e3149d1c68de8ff14007d2bbcbbc171a9d050d0a8772e836727329d4d3f130995ebaa19cf537d5d2f5ce2a88000366e6192e751457bfcc2125f351
   languageName: node
   linkType: hard
 
 "@firebase/app-check-interop-types@npm:0.3.3":
   version: 0.3.3
-  resolution: "@firebase/app-check-interop-types@npm:0.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fapp-check-interop-types%2F-%2Fapp-check-interop-types-0.3.3.tgz"
+  resolution: "@firebase/app-check-interop-types@npm:0.3.3"
   checksum: 10c0/4a887ef5e30ee1a407b569603c433a9f21244d50a19d97a5f1f17d8f5caea83096852b39e67d599f3238f1f7e2a369b02d184a184986a649ed1f8fed12fbd6be
   languageName: node
   linkType: hard
 
 "@firebase/app-types@npm:0.9.3":
   version: 0.9.3
-  resolution: "@firebase/app-types@npm:0.9.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fapp-types%2F-%2Fapp-types-0.9.3.tgz"
+  resolution: "@firebase/app-types@npm:0.9.3"
   checksum: 10c0/02ec9a26c10b9bbb2a1e5b9ae0552b5325b40066e3c23be089ceae53414a1505f2ab716ae1098652a0a0c9992ba322c05371a9b2a837cccfae309788372a72e0
   languageName: node
   linkType: hard
 
 "@firebase/auth-interop-types@npm:0.2.4":
   version: 0.2.4
-  resolution: "@firebase/auth-interop-types@npm:0.2.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fauth-interop-types%2F-%2Fauth-interop-types-0.2.4.tgz"
+  resolution: "@firebase/auth-interop-types@npm:0.2.4"
   checksum: 10c0/ff833bcbb472992c6061847309e338dac736c616522c5fd808526d6dc13b9788458a8c9677d91c33c1288ee38f42896c2b4b8fe10ee74f1569d11f3f3c4f53b5
   languageName: node
   linkType: hard
 
 "@firebase/component@npm:0.7.0":
   version: 0.7.0
-  resolution: "@firebase/component@npm:0.7.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fcomponent%2F-%2Fcomponent-0.7.0.tgz"
+  resolution: "@firebase/component@npm:0.7.0"
   dependencies:
     "@firebase/util": "npm:1.13.0"
     tslib: "npm:^2.1.0"
@@ -910,7 +910,7 @@ __metadata:
 
 "@firebase/database-compat@npm:^2.0.0":
   version: 2.1.0
-  resolution: "@firebase/database-compat@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fdatabase-compat%2F-%2Fdatabase-compat-2.1.0.tgz"
+  resolution: "@firebase/database-compat@npm:2.1.0"
   dependencies:
     "@firebase/component": "npm:0.7.0"
     "@firebase/database": "npm:1.1.0"
@@ -924,7 +924,7 @@ __metadata:
 
 "@firebase/database-types@npm:1.0.16, @firebase/database-types@npm:^1.0.6":
   version: 1.0.16
-  resolution: "@firebase/database-types@npm:1.0.16::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fdatabase-types%2F-%2Fdatabase-types-1.0.16.tgz"
+  resolution: "@firebase/database-types@npm:1.0.16"
   dependencies:
     "@firebase/app-types": "npm:0.9.3"
     "@firebase/util": "npm:1.13.0"
@@ -934,7 +934,7 @@ __metadata:
 
 "@firebase/database@npm:1.1.0":
   version: 1.1.0
-  resolution: "@firebase/database@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Fdatabase%2F-%2Fdatabase-1.1.0.tgz"
+  resolution: "@firebase/database@npm:1.1.0"
   dependencies:
     "@firebase/app-check-interop-types": "npm:0.3.3"
     "@firebase/auth-interop-types": "npm:0.2.4"
@@ -949,7 +949,7 @@ __metadata:
 
 "@firebase/logger@npm:0.5.0":
   version: 0.5.0
-  resolution: "@firebase/logger@npm:0.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Flogger%2F-%2Flogger-0.5.0.tgz"
+  resolution: "@firebase/logger@npm:0.5.0"
   dependencies:
     tslib: "npm:^2.1.0"
   checksum: 10c0/c9bfa2381b89b7dc674aeaaa497b73076041c56d6d65cbebcb3227c264b737394528d7f94658a7acb169bd14793cfcb33865207b2d32a7a6ac858e68c5c61b7e
@@ -958,7 +958,7 @@ __metadata:
 
 "@firebase/util@npm:1.13.0":
   version: 1.13.0
-  resolution: "@firebase/util@npm:1.13.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40firebase%2Futil%2F-%2Futil-1.13.0.tgz"
+  resolution: "@firebase/util@npm:1.13.0"
   dependencies:
     tslib: "npm:^2.1.0"
   checksum: 10c0/2e0c19dffdf69a1d1f8d786de551268d6af804de857eb195f4af50b732fe9e696cb73c52abc5f0bc98b34527225fb97a81ec380e89bd47a1d8448fc66536845c
@@ -967,7 +967,7 @@ __metadata:
 
 "@google-cloud/firestore@npm:^7.11.0":
   version: 7.11.6
-  resolution: "@google-cloud/firestore@npm:7.11.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40google-cloud%2Ffirestore%2F-%2Ffirestore-7.11.6.tgz"
+  resolution: "@google-cloud/firestore@npm:7.11.6"
   dependencies:
     "@opentelemetry/api": "npm:^1.3.0"
     fast-deep-equal: "npm:^3.1.1"
@@ -980,7 +980,7 @@ __metadata:
 
 "@google-cloud/paginator@npm:^5.0.0":
   version: 5.0.2
-  resolution: "@google-cloud/paginator@npm:5.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40google-cloud%2Fpaginator%2F-%2Fpaginator-5.0.2.tgz"
+  resolution: "@google-cloud/paginator@npm:5.0.2"
   dependencies:
     arrify: "npm:^2.0.0"
     extend: "npm:^3.0.2"
@@ -990,21 +990,21 @@ __metadata:
 
 "@google-cloud/projectify@npm:^4.0.0":
   version: 4.0.0
-  resolution: "@google-cloud/projectify@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40google-cloud%2Fprojectify%2F-%2Fprojectify-4.0.0.tgz"
+  resolution: "@google-cloud/projectify@npm:4.0.0"
   checksum: 10c0/0d0a6ceca76a138973fcb3ad577f209acdbd9d9aed1c645b09f98d5e5a258053dbbe6c1f13e6f85310cc0d9308f5f3a84f8fa4f1a132549a68d86174fb21067f
   languageName: node
   linkType: hard
 
 "@google-cloud/promisify@npm:<4.1.0":
   version: 4.0.0
-  resolution: "@google-cloud/promisify@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40google-cloud%2Fpromisify%2F-%2Fpromisify-4.0.0.tgz"
+  resolution: "@google-cloud/promisify@npm:4.0.0"
   checksum: 10c0/4332cbd923d7c6943ecdf46f187f1417c84bb9c801525cd74d719c766bfaad650f7964fb74576345f6537b6d6273a4f2992c8d79ebec6c8b8401b23d626b8dd3
   languageName: node
   linkType: hard
 
 "@google-cloud/storage@npm:^7.14.0":
   version: 7.18.0
-  resolution: "@google-cloud/storage@npm:7.18.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40google-cloud%2Fstorage%2F-%2Fstorage-7.18.0.tgz"
+  resolution: "@google-cloud/storage@npm:7.18.0"
   dependencies:
     "@google-cloud/paginator": "npm:^5.0.0"
     "@google-cloud/projectify": "npm:^4.0.0"
@@ -1027,7 +1027,7 @@ __metadata:
 
 "@grpc/grpc-js@npm:^1.10.9":
   version: 1.14.3
-  resolution: "@grpc/grpc-js@npm:1.14.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40grpc%2Fgrpc-js%2F-%2Fgrpc-js-1.14.3.tgz"
+  resolution: "@grpc/grpc-js@npm:1.14.3"
   dependencies:
     "@grpc/proto-loader": "npm:^0.8.0"
     "@js-sdsl/ordered-map": "npm:^4.4.2"
@@ -1037,7 +1037,7 @@ __metadata:
 
 "@grpc/proto-loader@npm:^0.7.13":
   version: 0.7.15
-  resolution: "@grpc/proto-loader@npm:0.7.15::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40grpc%2Fproto-loader%2F-%2Fproto-loader-0.7.15.tgz"
+  resolution: "@grpc/proto-loader@npm:0.7.15"
   dependencies:
     lodash.camelcase: "npm:^4.3.0"
     long: "npm:^5.0.0"
@@ -1051,7 +1051,7 @@ __metadata:
 
 "@grpc/proto-loader@npm:^0.8.0":
   version: 0.8.0
-  resolution: "@grpc/proto-loader@npm:0.8.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40grpc%2Fproto-loader%2F-%2Fproto-loader-0.8.0.tgz"
+  resolution: "@grpc/proto-loader@npm:0.8.0"
   dependencies:
     lodash.camelcase: "npm:^4.3.0"
     long: "npm:^5.0.0"
@@ -1065,14 +1065,14 @@ __metadata:
 
 "@inquirer/ansi@npm:^1.0.2":
   version: 1.0.2
-  resolution: "@inquirer/ansi@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fansi%2F-%2Fansi-1.0.2.tgz"
+  resolution: "@inquirer/ansi@npm:1.0.2"
   checksum: 10c0/8e408cc628923aa93402e66657482ccaa2ad5174f9db526d9a8b443f9011e9cd8f70f0f534f5fe3857b8a9df3bce1e25f66c96f666d6750490bd46e2b4f3b829
   languageName: node
   linkType: hard
 
 "@inquirer/checkbox@npm:^4.3.2":
   version: 4.3.2
-  resolution: "@inquirer/checkbox@npm:4.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fcheckbox%2F-%2Fcheckbox-4.3.2.tgz"
+  resolution: "@inquirer/checkbox@npm:4.3.2"
   dependencies:
     "@inquirer/ansi": "npm:^1.0.2"
     "@inquirer/core": "npm:^10.3.2"
@@ -1090,7 +1090,7 @@ __metadata:
 
 "@inquirer/confirm@npm:^5.1.21":
   version: 5.1.21
-  resolution: "@inquirer/confirm@npm:5.1.21::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fconfirm%2F-%2Fconfirm-5.1.21.tgz"
+  resolution: "@inquirer/confirm@npm:5.1.21"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/type": "npm:^3.0.10"
@@ -1105,7 +1105,7 @@ __metadata:
 
 "@inquirer/core@npm:^10.3.2":
   version: 10.3.2
-  resolution: "@inquirer/core@npm:10.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fcore%2F-%2Fcore-10.3.2.tgz"
+  resolution: "@inquirer/core@npm:10.3.2"
   dependencies:
     "@inquirer/ansi": "npm:^1.0.2"
     "@inquirer/figures": "npm:^1.0.15"
@@ -1126,7 +1126,7 @@ __metadata:
 
 "@inquirer/editor@npm:^4.2.23":
   version: 4.2.23
-  resolution: "@inquirer/editor@npm:4.2.23::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Feditor%2F-%2Feditor-4.2.23.tgz"
+  resolution: "@inquirer/editor@npm:4.2.23"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/external-editor": "npm:^1.0.3"
@@ -1142,7 +1142,7 @@ __metadata:
 
 "@inquirer/expand@npm:^4.0.23":
   version: 4.0.23
-  resolution: "@inquirer/expand@npm:4.0.23::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fexpand%2F-%2Fexpand-4.0.23.tgz"
+  resolution: "@inquirer/expand@npm:4.0.23"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/type": "npm:^3.0.10"
@@ -1158,7 +1158,7 @@ __metadata:
 
 "@inquirer/external-editor@npm:^1.0.2, @inquirer/external-editor@npm:^1.0.3":
   version: 1.0.3
-  resolution: "@inquirer/external-editor@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fexternal-editor%2F-%2Fexternal-editor-1.0.3.tgz"
+  resolution: "@inquirer/external-editor@npm:1.0.3"
   dependencies:
     chardet: "npm:^2.1.1"
     iconv-lite: "npm:^0.7.0"
@@ -1173,14 +1173,14 @@ __metadata:
 
 "@inquirer/figures@npm:^1.0.15":
   version: 1.0.15
-  resolution: "@inquirer/figures@npm:1.0.15::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Ffigures%2F-%2Ffigures-1.0.15.tgz"
+  resolution: "@inquirer/figures@npm:1.0.15"
   checksum: 10c0/6e39a040d260ae234ae220180b7994ff852673e20be925f8aa95e78c7934d732b018cbb4d0ec39e600a410461bcb93dca771e7de23caa10630d255692e440f69
   languageName: node
   linkType: hard
 
 "@inquirer/input@npm:^4.3.1":
   version: 4.3.1
-  resolution: "@inquirer/input@npm:4.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Finput%2F-%2Finput-4.3.1.tgz"
+  resolution: "@inquirer/input@npm:4.3.1"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/type": "npm:^3.0.10"
@@ -1195,7 +1195,7 @@ __metadata:
 
 "@inquirer/number@npm:^3.0.23":
   version: 3.0.23
-  resolution: "@inquirer/number@npm:3.0.23::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fnumber%2F-%2Fnumber-3.0.23.tgz"
+  resolution: "@inquirer/number@npm:3.0.23"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/type": "npm:^3.0.10"
@@ -1210,7 +1210,7 @@ __metadata:
 
 "@inquirer/password@npm:^4.0.23":
   version: 4.0.23
-  resolution: "@inquirer/password@npm:4.0.23::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fpassword%2F-%2Fpassword-4.0.23.tgz"
+  resolution: "@inquirer/password@npm:4.0.23"
   dependencies:
     "@inquirer/ansi": "npm:^1.0.2"
     "@inquirer/core": "npm:^10.3.2"
@@ -1226,7 +1226,7 @@ __metadata:
 
 "@inquirer/prompts@npm:^7.10.1":
   version: 7.10.1
-  resolution: "@inquirer/prompts@npm:7.10.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fprompts%2F-%2Fprompts-7.10.1.tgz"
+  resolution: "@inquirer/prompts@npm:7.10.1"
   dependencies:
     "@inquirer/checkbox": "npm:^4.3.2"
     "@inquirer/confirm": "npm:^5.1.21"
@@ -1249,7 +1249,7 @@ __metadata:
 
 "@inquirer/rawlist@npm:^4.1.11":
   version: 4.1.11
-  resolution: "@inquirer/rawlist@npm:4.1.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Frawlist%2F-%2Frawlist-4.1.11.tgz"
+  resolution: "@inquirer/rawlist@npm:4.1.11"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/type": "npm:^3.0.10"
@@ -1265,7 +1265,7 @@ __metadata:
 
 "@inquirer/search@npm:^3.2.2":
   version: 3.2.2
-  resolution: "@inquirer/search@npm:3.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fsearch%2F-%2Fsearch-3.2.2.tgz"
+  resolution: "@inquirer/search@npm:3.2.2"
   dependencies:
     "@inquirer/core": "npm:^10.3.2"
     "@inquirer/figures": "npm:^1.0.15"
@@ -1282,7 +1282,7 @@ __metadata:
 
 "@inquirer/select@npm:^4.4.2":
   version: 4.4.2
-  resolution: "@inquirer/select@npm:4.4.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fselect%2F-%2Fselect-4.4.2.tgz"
+  resolution: "@inquirer/select@npm:4.4.2"
   dependencies:
     "@inquirer/ansi": "npm:^1.0.2"
     "@inquirer/core": "npm:^10.3.2"
@@ -1300,7 +1300,7 @@ __metadata:
 
 "@inquirer/type@npm:^3.0.10":
   version: 3.0.10
-  resolution: "@inquirer/type@npm:3.0.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Ftype%2F-%2Ftype-3.0.10.tgz"
+  resolution: "@inquirer/type@npm:3.0.10"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
@@ -1312,21 +1312,21 @@ __metadata:
 
 "@ioredis/commands@npm:1.5.1":
   version: 1.5.1
-  resolution: "@ioredis/commands@npm:1.5.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40ioredis%2Fcommands%2F-%2Fcommands-1.5.1.tgz"
+  resolution: "@ioredis/commands@npm:1.5.1"
   checksum: 10c0/cb8f6d13cff0753e3e7ef001fb895491985d9a623248192538f13bc2fd9bfdfde3c18cf2ba6f20ec8ceaa681b0771070d3a09b82eed044c798bcfef5e3ae54b3
   languageName: node
   linkType: hard
 
 "@isaacs/balanced-match@npm:^4.0.1":
   version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40isaacs%2Fbalanced-match%2F-%2Fbalanced-match-4.0.1.tgz"
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
   checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
   languageName: node
   linkType: hard
 
 "@isaacs/brace-expansion@npm:^5.0.0":
   version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40isaacs%2Fbrace-expansion%2F-%2Fbrace-expansion-5.0.0.tgz"
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
   dependencies:
     "@isaacs/balanced-match": "npm:^4.0.1"
   checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
@@ -1335,7 +1335,7 @@ __metadata:
 
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
-  resolution: "@isaacs/fs-minipass@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40isaacs%2Ffs-minipass%2F-%2Ffs-minipass-4.0.1.tgz"
+  resolution: "@isaacs/fs-minipass@npm:4.0.1"
   dependencies:
     minipass: "npm:^7.0.4"
   checksum: 10c0/c25b6dc1598790d5b55c0947a9b7d111cfa92594db5296c3b907e2f533c033666f692a3939eadac17b1c7c40d362d0b0635dc874cbfe3e70db7c2b07cc97a5d2
@@ -1344,7 +1344,7 @@ __metadata:
 
 "@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
-  resolution: "@jridgewell/gen-mapping@npm:0.3.13::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Fgen-mapping%2F-%2Fgen-mapping-0.3.13.tgz"
+  resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
@@ -1354,7 +1354,7 @@ __metadata:
 
 "@jridgewell/remapping@npm:^2.3.5":
   version: 2.3.5
-  resolution: "@jridgewell/remapping@npm:2.3.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Fremapping%2F-%2Fremapping-2.3.5.tgz"
+  resolution: "@jridgewell/remapping@npm:2.3.5"
   dependencies:
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
@@ -1364,14 +1364,14 @@ __metadata:
 
 "@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
-  resolution: "@jridgewell/resolve-uri@npm:3.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Fresolve-uri%2F-%2Fresolve-uri-3.1.2.tgz"
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
   languageName: node
   linkType: hard
 
 "@jridgewell/source-map@npm:^0.3.3":
   version: 0.3.11
-  resolution: "@jridgewell/source-map@npm:0.3.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Fsource-map%2F-%2Fsource-map-0.3.11.tgz"
+  resolution: "@jridgewell/source-map@npm:0.3.11"
   dependencies:
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.25"
@@ -1381,14 +1381,14 @@ __metadata:
 
 "@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Fsourcemap-codec%2F-%2Fsourcemap-codec-1.5.5.tgz"
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
   languageName: node
   linkType: hard
 
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
-  resolution: "@jridgewell/trace-mapping@npm:0.3.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Ftrace-mapping%2F-%2Ftrace-mapping-0.3.9.tgz"
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.0.3"
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
@@ -1398,7 +1398,7 @@ __metadata:
 
 "@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.31":
   version: 0.3.31
-  resolution: "@jridgewell/trace-mapping@npm:0.3.31::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40jridgewell%2Ftrace-mapping%2F-%2Ftrace-mapping-0.3.31.tgz"
+  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
@@ -1408,14 +1408,14 @@ __metadata:
 
 "@js-sdsl/ordered-map@npm:^4.4.2":
   version: 4.4.2
-  resolution: "@js-sdsl/ordered-map@npm:4.4.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40js-sdsl%2Fordered-map%2F-%2Fordered-map-4.4.2.tgz"
+  resolution: "@js-sdsl/ordered-map@npm:4.4.2"
   checksum: 10c0/cc7e15dc4acf6d9ef663757279600bab70533d847dcc1ab01332e9e680bd30b77cdf9ad885cc774276f51d98b05a013571c940e5b360985af5eb798dc1a2ee2b
   languageName: node
   linkType: hard
 
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@manypkg/find-root@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40manypkg%2Ffind-root%2F-%2Ffind-root-1.1.0.tgz"
+  resolution: "@manypkg/find-root@npm:1.1.0"
   dependencies:
     "@babel/runtime": "npm:^7.5.5"
     "@types/node": "npm:^12.7.1"
@@ -1427,7 +1427,7 @@ __metadata:
 
 "@manypkg/get-packages@npm:^1.1.3":
   version: 1.1.3
-  resolution: "@manypkg/get-packages@npm:1.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40manypkg%2Fget-packages%2F-%2Fget-packages-1.1.3.tgz"
+  resolution: "@manypkg/get-packages@npm:1.1.3"
   dependencies:
     "@babel/runtime": "npm:^7.5.5"
     "@changesets/types": "npm:^4.0.1"
@@ -1441,14 +1441,14 @@ __metadata:
 
 "@module-federation/error-codes@npm:0.22.0":
   version: 0.22.0
-  resolution: "@module-federation/error-codes@npm:0.22.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40module-federation%2Ferror-codes%2F-%2Ferror-codes-0.22.0.tgz"
+  resolution: "@module-federation/error-codes@npm:0.22.0"
   checksum: 10c0/a9b25e8c930971e146e6352f482f915f1b54965ce54706984e834a87be714d30caebbd3946f9eb408e7821b2cc326b90787eeb2f8306edf1d322d9931543a139
   languageName: node
   linkType: hard
 
 "@module-federation/runtime-core@npm:0.22.0":
   version: 0.22.0
-  resolution: "@module-federation/runtime-core@npm:0.22.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40module-federation%2Fruntime-core%2F-%2Fruntime-core-0.22.0.tgz"
+  resolution: "@module-federation/runtime-core@npm:0.22.0"
   dependencies:
     "@module-federation/error-codes": "npm:0.22.0"
     "@module-federation/sdk": "npm:0.22.0"
@@ -1458,7 +1458,7 @@ __metadata:
 
 "@module-federation/runtime-tools@npm:0.22.0":
   version: 0.22.0
-  resolution: "@module-federation/runtime-tools@npm:0.22.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40module-federation%2Fruntime-tools%2F-%2Fruntime-tools-0.22.0.tgz"
+  resolution: "@module-federation/runtime-tools@npm:0.22.0"
   dependencies:
     "@module-federation/runtime": "npm:0.22.0"
     "@module-federation/webpack-bundler-runtime": "npm:0.22.0"
@@ -1468,7 +1468,7 @@ __metadata:
 
 "@module-federation/runtime@npm:0.22.0":
   version: 0.22.0
-  resolution: "@module-federation/runtime@npm:0.22.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40module-federation%2Fruntime%2F-%2Fruntime-0.22.0.tgz"
+  resolution: "@module-federation/runtime@npm:0.22.0"
   dependencies:
     "@module-federation/error-codes": "npm:0.22.0"
     "@module-federation/runtime-core": "npm:0.22.0"
@@ -1479,14 +1479,14 @@ __metadata:
 
 "@module-federation/sdk@npm:0.22.0":
   version: 0.22.0
-  resolution: "@module-federation/sdk@npm:0.22.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40module-federation%2Fsdk%2F-%2Fsdk-0.22.0.tgz"
+  resolution: "@module-federation/sdk@npm:0.22.0"
   checksum: 10c0/c09ba0147368151b67ba33b9174ef451a028e1709d2208aa811cacc1ae4efcae0f1987f02119f9b54754ee6430af3610e357c9b744147f112a25d8f7564f8041
   languageName: node
   linkType: hard
 
 "@module-federation/webpack-bundler-runtime@npm:0.22.0":
   version: 0.22.0
-  resolution: "@module-federation/webpack-bundler-runtime@npm:0.22.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40module-federation%2Fwebpack-bundler-runtime%2F-%2Fwebpack-bundler-runtime-0.22.0.tgz"
+  resolution: "@module-federation/webpack-bundler-runtime@npm:0.22.0"
   dependencies:
     "@module-federation/runtime": "npm:0.22.0"
     "@module-federation/sdk": "npm:0.22.0"
@@ -1496,7 +1496,7 @@ __metadata:
 
 "@napi-rs/wasm-runtime@npm:1.0.7":
   version: 1.0.7
-  resolution: "@napi-rs/wasm-runtime@npm:1.0.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40napi-rs%2Fwasm-runtime%2F-%2Fwasm-runtime-1.0.7.tgz"
+  resolution: "@napi-rs/wasm-runtime@npm:1.0.7"
   dependencies:
     "@emnapi/core": "npm:^1.5.0"
     "@emnapi/runtime": "npm:^1.5.0"
@@ -1507,7 +1507,7 @@ __metadata:
 
 "@napi-rs/wasm-runtime@npm:^1.0.7, @napi-rs/wasm-runtime@npm:^1.1.1":
   version: 1.1.1
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40napi-rs%2Fwasm-runtime%2F-%2Fwasm-runtime-1.1.1.tgz"
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
   dependencies:
     "@emnapi/core": "npm:^1.7.1"
     "@emnapi/runtime": "npm:^1.7.1"
@@ -1518,14 +1518,14 @@ __metadata:
 
 "@noble/hashes@npm:^1.1.5":
   version: 1.8.0
-  resolution: "@noble/hashes@npm:1.8.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40noble%2Fhashes%2F-%2Fhashes-1.8.0.tgz"
+  resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
   languageName: node
   linkType: hard
 
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
-  resolution: "@nodelib/fs.scandir@npm:2.1.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40nodelib%2Ffs.scandir%2F-%2Ffs.scandir-2.1.5.tgz"
+  resolution: "@nodelib/fs.scandir@npm:2.1.5"
   dependencies:
     "@nodelib/fs.stat": "npm:2.0.5"
     run-parallel: "npm:^1.1.9"
@@ -1535,14 +1535,14 @@ __metadata:
 
 "@nodelib/fs.stat@npm:2.0.5, @nodelib/fs.stat@npm:^2.0.2":
   version: 2.0.5
-  resolution: "@nodelib/fs.stat@npm:2.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40nodelib%2Ffs.stat%2F-%2Ffs.stat-2.0.5.tgz"
+  resolution: "@nodelib/fs.stat@npm:2.0.5"
   checksum: 10c0/88dafe5e3e29a388b07264680dc996c17f4bda48d163a9d4f5c1112979f0ce8ec72aa7116122c350b4e7976bc5566dc3ddb579be1ceaacc727872eb4ed93926d
   languageName: node
   linkType: hard
 
 "@nodelib/fs.walk@npm:^1.2.3":
   version: 1.2.8
-  resolution: "@nodelib/fs.walk@npm:1.2.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40nodelib%2Ffs.walk%2F-%2Ffs.walk-1.2.8.tgz"
+  resolution: "@nodelib/fs.walk@npm:1.2.8"
   dependencies:
     "@nodelib/fs.scandir": "npm:2.1.5"
     fastq: "npm:^1.6.0"
@@ -1552,7 +1552,7 @@ __metadata:
 
 "@npmcli/agent@npm:^4.0.0":
   version: 4.0.0
-  resolution: "@npmcli/agent@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40npmcli%2Fagent%2F-%2Fagent-4.0.0.tgz"
+  resolution: "@npmcli/agent@npm:4.0.0"
   dependencies:
     agent-base: "npm:^7.1.0"
     http-proxy-agent: "npm:^7.0.0"
@@ -1565,7 +1565,7 @@ __metadata:
 
 "@npmcli/fs@npm:^5.0.0":
   version: 5.0.0
-  resolution: "@npmcli/fs@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40npmcli%2Ffs%2F-%2Ffs-5.0.0.tgz"
+  resolution: "@npmcli/fs@npm:5.0.0"
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/26e376d780f60ff16e874a0ac9bc3399186846baae0b6e1352286385ac134d900cc5dafaded77f38d77f86898fc923ae1cee9d7399f0275b1aa24878915d722b
@@ -1574,98 +1574,98 @@ __metadata:
 
 "@opentelemetry/api@npm:^1.3.0":
   version: 1.9.0
-  resolution: "@opentelemetry/api@npm:1.9.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40opentelemetry%2Fapi%2F-%2Fapi-1.9.0.tgz"
+  resolution: "@opentelemetry/api@npm:1.9.0"
   checksum: 10c0/9aae2fe6e8a3a3eeb6c1fdef78e1939cf05a0f37f8a4fae4d6bf2e09eb1e06f966ece85805626e01ba5fab48072b94f19b835449e58b6d26720ee19a58298add
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-android-arm64@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-android-arm64@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-android-arm64%2F-%2Fbinding-android-arm64-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-android-arm64@npm:0.96.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-darwin-arm64@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-darwin-arm64%2F-%2Fbinding-darwin-arm64-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.96.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-darwin-x64@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-darwin-x64@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-darwin-x64%2F-%2Fbinding-darwin-x64-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-darwin-x64@npm:0.96.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-freebsd-x64@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-freebsd-x64%2F-%2Fbinding-freebsd-x64-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.96.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-arm-gnueabihf%2F-%2Fbinding-linux-arm-gnueabihf-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.96.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-arm-musleabihf@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-arm-musleabihf@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-arm-musleabihf%2F-%2Fbinding-linux-arm-musleabihf-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-arm-musleabihf@npm:0.96.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-arm64-gnu@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-arm64-gnu%2F-%2Fbinding-linux-arm64-gnu-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.96.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-arm64-musl@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-arm64-musl%2F-%2Fbinding-linux-arm64-musl-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.96.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-riscv64-gnu@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-riscv64-gnu%2F-%2Fbinding-linux-riscv64-gnu-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.96.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-s390x-gnu@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-s390x-gnu%2F-%2Fbinding-linux-s390x-gnu-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.96.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-x64-gnu@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-x64-gnu%2F-%2Fbinding-linux-x64-gnu-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.96.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-linux-x64-musl@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-linux-x64-musl%2F-%2Fbinding-linux-x64-musl-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.96.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-wasm32-wasi@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-wasm32-wasi@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-wasm32-wasi%2F-%2Fbinding-wasm32-wasi-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-wasm32-wasi@npm:0.96.0"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^1.0.7"
   conditions: cpu=wasm32
@@ -1674,140 +1674,140 @@ __metadata:
 
 "@oxc-parser/binding-win32-arm64-msvc@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-win32-arm64-msvc%2F-%2Fbinding-win32-arm64-msvc-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.96.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-parser/binding-win32-x64-msvc@npm:0.96.0":
   version: 0.96.0
-  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-parser%2Fbinding-win32-x64-msvc%2F-%2Fbinding-win32-x64-msvc-0.96.0.tgz"
+  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.96.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxc-project/types@npm:^0.96.0":
   version: 0.96.0
-  resolution: "@oxc-project/types@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-project%2Ftypes%2F-%2Ftypes-0.96.0.tgz"
+  resolution: "@oxc-project/types@npm:0.96.0"
   checksum: 10c0/8d2770c551e0cb2efc77fb7d0711a2e19080dd9cd1e221ff95b3fae6d29c7f38165b1443eafc712956a215d607a4c8d4c1aad6bf26cb7069a391b27290aa6e8e
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-android-arm-eabi@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-android-arm-eabi%2F-%2Fbinding-android-arm-eabi-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.16.3"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-android-arm64@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-android-arm64@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-android-arm64%2F-%2Fbinding-android-arm64-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-android-arm64@npm:11.16.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-darwin-arm64@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-darwin-arm64%2F-%2Fbinding-darwin-arm64-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-darwin-arm64@npm:11.16.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-darwin-x64@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-darwin-x64%2F-%2Fbinding-darwin-x64-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-darwin-x64@npm:11.16.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-freebsd-x64@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-freebsd-x64%2F-%2Fbinding-freebsd-x64-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-freebsd-x64@npm:11.16.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-arm-gnueabihf%2F-%2Fbinding-linux-arm-gnueabihf-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-arm-gnueabihf@npm:11.16.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-arm-musleabihf%2F-%2Fbinding-linux-arm-musleabihf-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-arm-musleabihf@npm:11.16.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-arm64-gnu@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-arm64-gnu%2F-%2Fbinding-linux-arm64-gnu-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-arm64-gnu@npm:11.16.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-arm64-musl@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-arm64-musl%2F-%2Fbinding-linux-arm64-musl-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-arm64-musl@npm:11.16.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-ppc64-gnu%2F-%2Fbinding-linux-ppc64-gnu-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-ppc64-gnu@npm:11.16.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-riscv64-gnu%2F-%2Fbinding-linux-riscv64-gnu-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-riscv64-gnu@npm:11.16.3"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-riscv64-musl@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-riscv64-musl%2F-%2Fbinding-linux-riscv64-musl-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-riscv64-musl@npm:11.16.3"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-s390x-gnu@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-s390x-gnu%2F-%2Fbinding-linux-s390x-gnu-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-s390x-gnu@npm:11.16.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-x64-gnu@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-x64-gnu%2F-%2Fbinding-linux-x64-gnu-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-x64-gnu@npm:11.16.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-linux-x64-musl@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-linux-x64-musl%2F-%2Fbinding-linux-x64-musl-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-linux-x64-musl@npm:11.16.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-openharmony-arm64@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-openharmony-arm64%2F-%2Fbinding-openharmony-arm64-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-openharmony-arm64@npm:11.16.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-wasm32-wasi@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-wasm32-wasi%2F-%2Fbinding-wasm32-wasi-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-wasm32-wasi@npm:11.16.3"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^1.1.1"
   conditions: cpu=wasm32
@@ -1816,84 +1816,84 @@ __metadata:
 
 "@oxc-resolver/binding-win32-arm64-msvc@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-win32-arm64-msvc%2F-%2Fbinding-win32-arm64-msvc-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-win32-arm64-msvc@npm:11.16.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-win32-ia32-msvc@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-win32-ia32-msvc%2F-%2Fbinding-win32-ia32-msvc-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-win32-ia32-msvc@npm:11.16.3"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@oxc-resolver/binding-win32-x64-msvc@npm:11.16.3":
   version: 11.16.3
-  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxc-resolver%2Fbinding-win32-x64-msvc%2F-%2Fbinding-win32-x64-msvc-11.16.3.tgz"
+  resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.16.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxlint/darwin-arm64@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/darwin-arm64@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Fdarwin-arm64%2F-%2Fdarwin-arm64-1.39.0.tgz"
+  resolution: "@oxlint/darwin-arm64@npm:1.39.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxlint/darwin-x64@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/darwin-x64@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Fdarwin-x64%2F-%2Fdarwin-x64-1.39.0.tgz"
+  resolution: "@oxlint/darwin-x64@npm:1.39.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@oxlint/linux-arm64-gnu@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/linux-arm64-gnu@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Flinux-arm64-gnu%2F-%2Flinux-arm64-gnu-1.39.0.tgz"
+  resolution: "@oxlint/linux-arm64-gnu@npm:1.39.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxlint/linux-arm64-musl@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/linux-arm64-musl@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Flinux-arm64-musl%2F-%2Flinux-arm64-musl-1.39.0.tgz"
+  resolution: "@oxlint/linux-arm64-musl@npm:1.39.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxlint/linux-x64-gnu@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/linux-x64-gnu@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Flinux-x64-gnu%2F-%2Flinux-x64-gnu-1.39.0.tgz"
+  resolution: "@oxlint/linux-x64-gnu@npm:1.39.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@oxlint/linux-x64-musl@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/linux-x64-musl@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Flinux-x64-musl%2F-%2Flinux-x64-musl-1.39.0.tgz"
+  resolution: "@oxlint/linux-x64-musl@npm:1.39.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@oxlint/win32-arm64@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/win32-arm64@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Fwin32-arm64%2F-%2Fwin32-arm64-1.39.0.tgz"
+  resolution: "@oxlint/win32-arm64@npm:1.39.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@oxlint/win32-x64@npm:1.39.0":
   version: 1.39.0
-  resolution: "@oxlint/win32-x64@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40oxlint%2Fwin32-x64%2F-%2Fwin32-x64-1.39.0.tgz"
+  resolution: "@oxlint/win32-x64@npm:1.39.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@paralleldrive/cuid2@npm:^2.2.2":
   version: 2.3.1
-  resolution: "@paralleldrive/cuid2@npm:2.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40paralleldrive%2Fcuid2%2F-%2Fcuid2-2.3.1.tgz"
+  resolution: "@paralleldrive/cuid2@npm:2.3.1"
   dependencies:
     "@noble/hashes": "npm:^1.1.5"
   checksum: 10c0/6576b73de49d826b0f33cbab88424dec1f6fa454a9e59a7b621f78c2cfdd2e59d7f48175826d698940a717f45eeb5e87a508583a7316e608f6a05a861a40c129
@@ -1902,98 +1902,98 @@ __metadata:
 
 "@parcel/watcher-android-arm64@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-android-arm64@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-android-arm64%2F-%2Fwatcher-android-arm64-2.5.4.tgz"
+  resolution: "@parcel/watcher-android-arm64@npm:2.5.4"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
 "@parcel/watcher-darwin-arm64@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-darwin-arm64@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-darwin-arm64%2F-%2Fwatcher-darwin-arm64-2.5.4.tgz"
+  resolution: "@parcel/watcher-darwin-arm64@npm:2.5.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@parcel/watcher-darwin-x64@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-darwin-x64@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-darwin-x64%2F-%2Fwatcher-darwin-x64-2.5.4.tgz"
+  resolution: "@parcel/watcher-darwin-x64@npm:2.5.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@parcel/watcher-freebsd-x64@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-freebsd-x64@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-freebsd-x64%2F-%2Fwatcher-freebsd-x64-2.5.4.tgz"
+  resolution: "@parcel/watcher-freebsd-x64@npm:2.5.4"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@parcel/watcher-linux-arm-glibc@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-linux-arm-glibc@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-linux-arm-glibc%2F-%2Fwatcher-linux-arm-glibc-2.5.4.tgz"
+  resolution: "@parcel/watcher-linux-arm-glibc@npm:2.5.4"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
 "@parcel/watcher-linux-arm-musl@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-linux-arm-musl@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-linux-arm-musl%2F-%2Fwatcher-linux-arm-musl-2.5.4.tgz"
+  resolution: "@parcel/watcher-linux-arm-musl@npm:2.5.4"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
 "@parcel/watcher-linux-arm64-glibc@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-linux-arm64-glibc@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-linux-arm64-glibc%2F-%2Fwatcher-linux-arm64-glibc-2.5.4.tgz"
+  resolution: "@parcel/watcher-linux-arm64-glibc@npm:2.5.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@parcel/watcher-linux-arm64-musl@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-linux-arm64-musl@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-linux-arm64-musl%2F-%2Fwatcher-linux-arm64-musl-2.5.4.tgz"
+  resolution: "@parcel/watcher-linux-arm64-musl@npm:2.5.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@parcel/watcher-linux-x64-glibc@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-linux-x64-glibc@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-linux-x64-glibc%2F-%2Fwatcher-linux-x64-glibc-2.5.4.tgz"
+  resolution: "@parcel/watcher-linux-x64-glibc@npm:2.5.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@parcel/watcher-linux-x64-musl@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-linux-x64-musl@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-linux-x64-musl%2F-%2Fwatcher-linux-x64-musl-2.5.4.tgz"
+  resolution: "@parcel/watcher-linux-x64-musl@npm:2.5.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@parcel/watcher-win32-arm64@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-win32-arm64@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-win32-arm64%2F-%2Fwatcher-win32-arm64-2.5.4.tgz"
+  resolution: "@parcel/watcher-win32-arm64@npm:2.5.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@parcel/watcher-win32-ia32@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-win32-ia32@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-win32-ia32%2F-%2Fwatcher-win32-ia32-2.5.4.tgz"
+  resolution: "@parcel/watcher-win32-ia32@npm:2.5.4"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@parcel/watcher-win32-x64@npm:2.5.4":
   version: 2.5.4
-  resolution: "@parcel/watcher-win32-x64@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher-win32-x64%2F-%2Fwatcher-win32-x64-2.5.4.tgz"
+  resolution: "@parcel/watcher-win32-x64@npm:2.5.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@parcel/watcher@npm:^2.4.1":
   version: 2.5.4
-  resolution: "@parcel/watcher@npm:2.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40parcel%2Fwatcher%2F-%2Fwatcher-2.5.4.tgz"
+  resolution: "@parcel/watcher@npm:2.5.4"
   dependencies:
     "@parcel/watcher-android-arm64": "npm:2.5.4"
     "@parcel/watcher-darwin-arm64": "npm:2.5.4"
@@ -2046,21 +2046,21 @@ __metadata:
 
 "@pkgr/core@npm:^0.2.7":
   version: 0.2.9
-  resolution: "@pkgr/core@npm:0.2.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40pkgr%2Fcore%2F-%2Fcore-0.2.9.tgz"
+  resolution: "@pkgr/core@npm:0.2.9"
   checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
   languageName: node
   linkType: hard
 
 "@pnpm/config.env-replace@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@pnpm/config.env-replace@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40pnpm%2Fconfig.env-replace%2F-%2Fconfig.env-replace-1.1.0.tgz"
+  resolution: "@pnpm/config.env-replace@npm:1.1.0"
   checksum: 10c0/4cfc4a5c49ab3d0c6a1f196cfd4146374768b0243d441c7de8fa7bd28eaab6290f514b98490472cc65dbd080d34369447b3e9302585e1d5c099befd7c8b5e55f
   languageName: node
   linkType: hard
 
 "@pnpm/network.ca-file@npm:^1.0.1":
   version: 1.0.2
-  resolution: "@pnpm/network.ca-file@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40pnpm%2Fnetwork.ca-file%2F-%2Fnetwork.ca-file-1.0.2.tgz"
+  resolution: "@pnpm/network.ca-file@npm:1.0.2"
   dependencies:
     graceful-fs: "npm:4.2.10"
   checksum: 10c0/95f6e0e38d047aca3283550719155ce7304ac00d98911e4ab026daedaf640a63bd83e3d13e17c623fa41ac72f3801382ba21260bcce431c14fbbc06430ecb776
@@ -2069,7 +2069,7 @@ __metadata:
 
 "@pnpm/npm-conf@npm:^3.0.2":
   version: 3.0.2
-  resolution: "@pnpm/npm-conf@npm:3.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40pnpm%2Fnpm-conf%2F-%2Fnpm-conf-3.0.2.tgz"
+  resolution: "@pnpm/npm-conf@npm:3.0.2"
   dependencies:
     "@pnpm/config.env-replace": "npm:^1.1.0"
     "@pnpm/network.ca-file": "npm:^1.0.1"
@@ -2080,42 +2080,42 @@ __metadata:
 
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
-  resolution: "@polka/url@npm:1.0.0-next.29::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40polka%2Furl%2F-%2Furl-1.0.0-next.29.tgz"
+  resolution: "@polka/url@npm:1.0.0-next.29"
   checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
   languageName: node
   linkType: hard
 
 "@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
   version: 1.1.2
-  resolution: "@protobufjs/aspromise@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Faspromise%2F-%2Faspromise-1.1.2.tgz"
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
   checksum: 10c0/a83343a468ff5b5ec6bff36fd788a64c839e48a07ff9f4f813564f58caf44d011cd6504ed2147bf34835bd7a7dd2107052af755961c6b098fd8902b4f6500d0f
   languageName: node
   linkType: hard
 
 "@protobufjs/base64@npm:^1.1.2":
   version: 1.1.2
-  resolution: "@protobufjs/base64@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Fbase64%2F-%2Fbase64-1.1.2.tgz"
+  resolution: "@protobufjs/base64@npm:1.1.2"
   checksum: 10c0/eec925e681081af190b8ee231f9bad3101e189abbc182ff279da6b531e7dbd2a56f1f306f37a80b1be9e00aa2d271690d08dcc5f326f71c9eed8546675c8caf6
   languageName: node
   linkType: hard
 
 "@protobufjs/codegen@npm:^2.0.4":
   version: 2.0.4
-  resolution: "@protobufjs/codegen@npm:2.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Fcodegen%2F-%2Fcodegen-2.0.4.tgz"
+  resolution: "@protobufjs/codegen@npm:2.0.4"
   checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
   languageName: node
   linkType: hard
 
 "@protobufjs/eventemitter@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Feventemitter%2F-%2Feventemitter-1.1.0.tgz"
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
   checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
   languageName: node
   linkType: hard
 
 "@protobufjs/fetch@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@protobufjs/fetch@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Ffetch%2F-%2Ffetch-1.1.0.tgz"
+  resolution: "@protobufjs/fetch@npm:1.1.0"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.1"
     "@protobufjs/inquire": "npm:^1.1.0"
@@ -2125,217 +2125,217 @@ __metadata:
 
 "@protobufjs/float@npm:^1.0.2":
   version: 1.0.2
-  resolution: "@protobufjs/float@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Ffloat%2F-%2Ffloat-1.0.2.tgz"
+  resolution: "@protobufjs/float@npm:1.0.2"
   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
   languageName: node
   linkType: hard
 
 "@protobufjs/inquire@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@protobufjs/inquire@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Finquire%2F-%2Finquire-1.1.0.tgz"
+  resolution: "@protobufjs/inquire@npm:1.1.0"
   checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
   languageName: node
   linkType: hard
 
 "@protobufjs/path@npm:^1.1.2":
   version: 1.1.2
-  resolution: "@protobufjs/path@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Fpath%2F-%2Fpath-1.1.2.tgz"
+  resolution: "@protobufjs/path@npm:1.1.2"
   checksum: 10c0/cece0a938e7f5dfd2fa03f8c14f2f1cf8b0d6e13ac7326ff4c96ea311effd5fb7ae0bba754fbf505312af2e38500250c90e68506b97c02360a43793d88a0d8b4
   languageName: node
   linkType: hard
 
 "@protobufjs/pool@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@protobufjs/pool@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Fpool%2F-%2Fpool-1.1.0.tgz"
+  resolution: "@protobufjs/pool@npm:1.1.0"
   checksum: 10c0/eda2718b7f222ac6e6ad36f758a92ef90d26526026a19f4f17f668f45e0306a5bd734def3f48f51f8134ae0978b6262a5c517c08b115a551756d1a3aadfcf038
   languageName: node
   linkType: hard
 
 "@protobufjs/utf8@npm:^1.1.0":
   version: 1.1.0
-  resolution: "@protobufjs/utf8@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40protobufjs%2Futf8%2F-%2Futf8-1.1.0.tgz"
+  resolution: "@protobufjs/utf8@npm:1.1.0"
   checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
   languageName: node
   linkType: hard
 
 "@rollup/rollup-android-arm-eabi@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-android-arm-eabi%2F-%2Frollup-android-arm-eabi-4.55.1.tgz"
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.55.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
 "@rollup/rollup-android-arm64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-android-arm64%2F-%2Frollup-android-arm64-4.55.1.tgz"
+  resolution: "@rollup/rollup-android-arm64@npm:4.55.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-darwin-arm64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-darwin-arm64%2F-%2Frollup-darwin-arm64-4.55.1.tgz"
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.55.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-darwin-x64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-darwin-x64%2F-%2Frollup-darwin-x64-4.55.1.tgz"
+  resolution: "@rollup/rollup-darwin-x64@npm:4.55.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-freebsd-arm64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-freebsd-arm64%2F-%2Frollup-freebsd-arm64-4.55.1.tgz"
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.55.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-freebsd-x64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-freebsd-x64%2F-%2Frollup-freebsd-x64-4.55.1.tgz"
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.55.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-arm-gnueabihf@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-arm-gnueabihf%2F-%2Frollup-linux-arm-gnueabihf-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.55.1"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-arm-musleabihf@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-arm-musleabihf%2F-%2Frollup-linux-arm-musleabihf-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.55.1"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-arm64-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-arm64-gnu%2F-%2Frollup-linux-arm64-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.55.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-arm64-musl@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-arm64-musl%2F-%2Frollup-linux-arm64-musl-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.55.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-loong64-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-loong64-gnu%2F-%2Frollup-linux-loong64-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.55.1"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-loong64-musl@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-loong64-musl%2F-%2Frollup-linux-loong64-musl-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.55.1"
   conditions: os=linux & cpu=loong64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-ppc64-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-ppc64-gnu%2F-%2Frollup-linux-ppc64-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.55.1"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-ppc64-musl@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-ppc64-musl%2F-%2Frollup-linux-ppc64-musl-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.55.1"
   conditions: os=linux & cpu=ppc64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-riscv64-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-riscv64-gnu%2F-%2Frollup-linux-riscv64-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.55.1"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-riscv64-musl@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-riscv64-musl%2F-%2Frollup-linux-riscv64-musl-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.55.1"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-s390x-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-s390x-gnu%2F-%2Frollup-linux-s390x-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.55.1"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-x64-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-x64-gnu%2F-%2Frollup-linux-x64-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.55.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rollup/rollup-linux-x64-musl@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-linux-x64-musl%2F-%2Frollup-linux-x64-musl-4.55.1.tgz"
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.55.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rollup/rollup-openbsd-x64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-openbsd-x64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-openbsd-x64%2F-%2Frollup-openbsd-x64-4.55.1.tgz"
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.55.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-openharmony-arm64@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-openharmony-arm64@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-openharmony-arm64%2F-%2Frollup-openharmony-arm64-4.55.1.tgz"
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.55.1"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-win32-arm64-msvc@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-win32-arm64-msvc%2F-%2Frollup-win32-arm64-msvc-4.55.1.tgz"
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.55.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-win32-ia32-msvc@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-win32-ia32-msvc%2F-%2Frollup-win32-ia32-msvc-4.55.1.tgz"
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.55.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@rollup/rollup-win32-x64-gnu@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-win32-x64-gnu%2F-%2Frollup-win32-x64-gnu-4.55.1.tgz"
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.55.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@rollup/rollup-win32-x64-msvc@npm:4.55.1":
   version: 4.55.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rollup%2Frollup-win32-x64-msvc%2F-%2Frollup-win32-x64-msvc-4.55.1.tgz"
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.55.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@rsbuild/plugin-check-syntax@npm:1.6.0":
   version: 1.6.0
-  resolution: "@rsbuild/plugin-check-syntax@npm:1.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsbuild%2Fplugin-check-syntax%2F-%2Fplugin-check-syntax-1.6.0.tgz"
+  resolution: "@rsbuild/plugin-check-syntax@npm:1.6.0"
   dependencies:
     acorn: "npm:^8.15.0"
     browserslist-to-es-version: "npm:^1.2.0"
@@ -2353,14 +2353,14 @@ __metadata:
 
 "@rsdoctor/client@npm:1.5.0":
   version: 1.5.0
-  resolution: "@rsdoctor/client@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Fclient%2F-%2Fclient-1.5.0.tgz"
+  resolution: "@rsdoctor/client@npm:1.5.0"
   checksum: 10c0/4d4a254185acffec07ce6e0ee72dee57f6e680321fca3bcc8920903804e4e408a02b52b74b58be9720a42229b02d947e0e709cb7258970ac4fdc653acf31a801
   languageName: node
   linkType: hard
 
 "@rsdoctor/core@npm:1.5.0":
   version: 1.5.0
-  resolution: "@rsdoctor/core@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Fcore%2F-%2Fcore-1.5.0.tgz"
+  resolution: "@rsdoctor/core@npm:1.5.0"
   dependencies:
     "@rsbuild/plugin-check-syntax": "npm:1.6.0"
     "@rsdoctor/graph": "npm:1.5.0"
@@ -2380,7 +2380,7 @@ __metadata:
 
 "@rsdoctor/graph@npm:1.5.0":
   version: 1.5.0
-  resolution: "@rsdoctor/graph@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Fgraph%2F-%2Fgraph-1.5.0.tgz"
+  resolution: "@rsdoctor/graph@npm:1.5.0"
   dependencies:
     "@rsdoctor/types": "npm:1.5.0"
     "@rsdoctor/utils": "npm:1.5.0"
@@ -2393,7 +2393,7 @@ __metadata:
 
 "@rsdoctor/rspack-plugin@npm:^1.3.8":
   version: 1.5.0
-  resolution: "@rsdoctor/rspack-plugin@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Frspack-plugin%2F-%2Frspack-plugin-1.5.0.tgz"
+  resolution: "@rsdoctor/rspack-plugin@npm:1.5.0"
   dependencies:
     "@rsdoctor/core": "npm:1.5.0"
     "@rsdoctor/graph": "npm:1.5.0"
@@ -2411,7 +2411,7 @@ __metadata:
 
 "@rsdoctor/sdk@npm:1.5.0":
   version: 1.5.0
-  resolution: "@rsdoctor/sdk@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Fsdk%2F-%2Fsdk-1.5.0.tgz"
+  resolution: "@rsdoctor/sdk@npm:1.5.0"
   dependencies:
     "@rsdoctor/client": "npm:1.5.0"
     "@rsdoctor/graph": "npm:1.5.0"
@@ -2426,7 +2426,7 @@ __metadata:
 
 "@rsdoctor/types@npm:1.5.0":
   version: 1.5.0
-  resolution: "@rsdoctor/types@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Ftypes%2F-%2Ftypes-1.5.0.tgz"
+  resolution: "@rsdoctor/types@npm:1.5.0"
   dependencies:
     "@types/connect": "npm:3.4.38"
     "@types/estree": "npm:1.0.5"
@@ -2446,7 +2446,7 @@ __metadata:
 
 "@rsdoctor/utils@npm:1.5.0":
   version: 1.5.0
-  resolution: "@rsdoctor/utils@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rsdoctor%2Futils%2F-%2Futils-1.5.0.tgz"
+  resolution: "@rsdoctor/utils@npm:1.5.0"
   dependencies:
     "@babel/code-frame": "npm:7.26.2"
     "@rsdoctor/types": "npm:1.5.0"
@@ -2469,49 +2469,49 @@ __metadata:
 
 "@rspack/binding-darwin-arm64@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-darwin-arm64@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-darwin-arm64%2F-%2Fbinding-darwin-arm64-1.7.2.tgz"
+  resolution: "@rspack/binding-darwin-arm64@npm:1.7.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rspack/binding-darwin-x64@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-darwin-x64@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-darwin-x64%2F-%2Fbinding-darwin-x64-1.7.2.tgz"
+  resolution: "@rspack/binding-darwin-x64@npm:1.7.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@rspack/binding-linux-arm64-gnu@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-linux-arm64-gnu@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-linux-arm64-gnu%2F-%2Fbinding-linux-arm64-gnu-1.7.2.tgz"
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:1.7.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rspack/binding-linux-arm64-musl@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-linux-arm64-musl@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-linux-arm64-musl%2F-%2Fbinding-linux-arm64-musl-1.7.2.tgz"
+  resolution: "@rspack/binding-linux-arm64-musl@npm:1.7.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rspack/binding-linux-x64-gnu@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-linux-x64-gnu@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-linux-x64-gnu%2F-%2Fbinding-linux-x64-gnu-1.7.2.tgz"
+  resolution: "@rspack/binding-linux-x64-gnu@npm:1.7.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rspack/binding-linux-x64-musl@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-linux-x64-musl@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-linux-x64-musl%2F-%2Fbinding-linux-x64-musl-1.7.2.tgz"
+  resolution: "@rspack/binding-linux-x64-musl@npm:1.7.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@rspack/binding-wasm32-wasi@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-wasm32-wasi@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-wasm32-wasi%2F-%2Fbinding-wasm32-wasi-1.7.2.tgz"
+  resolution: "@rspack/binding-wasm32-wasi@npm:1.7.2"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:1.0.7"
   conditions: cpu=wasm32
@@ -2520,28 +2520,28 @@ __metadata:
 
 "@rspack/binding-win32-arm64-msvc@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-win32-arm64-msvc@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-win32-arm64-msvc%2F-%2Fbinding-win32-arm64-msvc-1.7.2.tgz"
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:1.7.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@rspack/binding-win32-ia32-msvc@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-win32-ia32-msvc@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-win32-ia32-msvc%2F-%2Fbinding-win32-ia32-msvc-1.7.2.tgz"
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:1.7.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@rspack/binding-win32-x64-msvc@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding-win32-x64-msvc@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding-win32-x64-msvc%2F-%2Fbinding-win32-x64-msvc-1.7.2.tgz"
+  resolution: "@rspack/binding-win32-x64-msvc@npm:1.7.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@rspack/binding@npm:1.7.2":
   version: 1.7.2
-  resolution: "@rspack/binding@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fbinding%2F-%2Fbinding-1.7.2.tgz"
+  resolution: "@rspack/binding@npm:1.7.2"
   dependencies:
     "@rspack/binding-darwin-arm64": "npm:1.7.2"
     "@rspack/binding-darwin-x64": "npm:1.7.2"
@@ -2580,7 +2580,7 @@ __metadata:
 
 "@rspack/core@npm:^1.6.0":
   version: 1.7.2
-  resolution: "@rspack/core@npm:1.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Fcore%2F-%2Fcore-1.7.2.tgz"
+  resolution: "@rspack/core@npm:1.7.2"
   dependencies:
     "@module-federation/runtime-tools": "npm:0.22.0"
     "@rspack/binding": "npm:1.7.2"
@@ -2596,14 +2596,14 @@ __metadata:
 
 "@rspack/lite-tapable@npm:1.1.0":
   version: 1.1.0
-  resolution: "@rspack/lite-tapable@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40rspack%2Flite-tapable%2F-%2Flite-tapable-1.1.0.tgz"
+  resolution: "@rspack/lite-tapable@npm:1.1.0"
   checksum: 10c0/15059d1da73192b150339ceba3142a2d0073fa298dad9a497cc8c6037c597c3a982ed4c88dc50afa7b70d0757df1b47af7ae407cfe8acd31d333d524b84a7a4b
   languageName: node
   linkType: hard
 
 "@samverschueren/stream-to-observable@npm:^0.3.0":
   version: 0.3.1
-  resolution: "@samverschueren/stream-to-observable@npm:0.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40samverschueren%2Fstream-to-observable%2F-%2Fstream-to-observable-0.3.1.tgz"
+  resolution: "@samverschueren/stream-to-observable@npm:0.3.1"
   dependencies:
     any-observable: "npm:^0.3.0"
   peerDependenciesMeta:
@@ -2617,105 +2617,105 @@ __metadata:
 
 "@sindresorhus/is@npm:^0.15.0":
   version: 0.15.0
-  resolution: "@sindresorhus/is@npm:0.15.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40sindresorhus%2Fis%2F-%2Fis-0.15.0.tgz"
+  resolution: "@sindresorhus/is@npm:0.15.0"
   checksum: 10c0/1d7dba430c13dd2e1a977d9191e0137a131dd83e7166fb1b69378e6627b5baef267d09ed11e5753b24c8e852ad5cdbcab9573b1c9a4bdc2992a1b06aa872517e
   languageName: node
   linkType: hard
 
 "@sindresorhus/merge-streams@npm:^2.1.0":
   version: 2.3.0
-  resolution: "@sindresorhus/merge-streams@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40sindresorhus%2Fmerge-streams%2F-%2Fmerge-streams-2.3.0.tgz"
+  resolution: "@sindresorhus/merge-streams@npm:2.3.0"
   checksum: 10c0/69ee906f3125fb2c6bb6ec5cdd84e8827d93b49b3892bce8b62267116cc7e197b5cccf20c160a1d32c26014ecd14470a72a5e3ee37a58f1d6dadc0db1ccf3894
   languageName: node
   linkType: hard
 
 "@socket.io/component-emitter@npm:~3.1.0":
   version: 3.1.2
-  resolution: "@socket.io/component-emitter@npm:3.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40socket.io%2Fcomponent-emitter%2F-%2Fcomponent-emitter-3.1.2.tgz"
+  resolution: "@socket.io/component-emitter@npm:3.1.2"
   checksum: 10c0/c4242bad66f67e6f7b712733d25b43cbb9e19a595c8701c3ad99cbeb5901555f78b095e24852f862fffb43e96f1d8552e62def885ca82ae1bb05da3668fd87d7
   languageName: node
   linkType: hard
 
 "@standard-schema/spec@npm:^1.0.0":
   version: 1.1.0
-  resolution: "@standard-schema/spec@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40standard-schema%2Fspec%2F-%2Fspec-1.1.0.tgz"
+  resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
   languageName: node
   linkType: hard
 
 "@swc/core-darwin-arm64@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-darwin-arm64@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-darwin-arm64%2F-%2Fcore-darwin-arm64-1.15.8.tgz"
+  resolution: "@swc/core-darwin-arm64@npm:1.15.8"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
 "@swc/core-darwin-x64@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-darwin-x64@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-darwin-x64%2F-%2Fcore-darwin-x64-1.15.8.tgz"
+  resolution: "@swc/core-darwin-x64@npm:1.15.8"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
 "@swc/core-linux-arm-gnueabihf@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-linux-arm-gnueabihf%2F-%2Fcore-linux-arm-gnueabihf-1.15.8.tgz"
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.8"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
 "@swc/core-linux-arm64-gnu@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-linux-arm64-gnu%2F-%2Fcore-linux-arm64-gnu-1.15.8.tgz"
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.8"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@swc/core-linux-arm64-musl@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-linux-arm64-musl@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-linux-arm64-musl%2F-%2Fcore-linux-arm64-musl-1.15.8.tgz"
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.8"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
 "@swc/core-linux-x64-gnu@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-linux-x64-gnu@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-linux-x64-gnu%2F-%2Fcore-linux-x64-gnu-1.15.8.tgz"
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.8"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@swc/core-linux-x64-musl@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-linux-x64-musl@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-linux-x64-musl%2F-%2Fcore-linux-x64-musl-1.15.8.tgz"
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.8"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
 "@swc/core-win32-arm64-msvc@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-win32-arm64-msvc%2F-%2Fcore-win32-arm64-msvc-1.15.8.tgz"
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.8"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
 "@swc/core-win32-ia32-msvc@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-win32-ia32-msvc%2F-%2Fcore-win32-ia32-msvc-1.15.8.tgz"
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.8"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
 "@swc/core-win32-x64-msvc@npm:1.15.8":
   version: 1.15.8
-  resolution: "@swc/core-win32-x64-msvc@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore-win32-x64-msvc%2F-%2Fcore-win32-x64-msvc-1.15.8.tgz"
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.8"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@swc/core@npm:^1.14.0":
   version: 1.15.8
-  resolution: "@swc/core@npm:1.15.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcore%2F-%2Fcore-1.15.8.tgz"
+  resolution: "@swc/core@npm:1.15.8"
   dependencies:
     "@swc/core-darwin-arm64": "npm:1.15.8"
     "@swc/core-darwin-x64": "npm:1.15.8"
@@ -2761,14 +2761,14 @@ __metadata:
 
 "@swc/counter@npm:^0.1.3":
   version: 0.1.3
-  resolution: "@swc/counter@npm:0.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Fcounter%2F-%2Fcounter-0.1.3.tgz"
+  resolution: "@swc/counter@npm:0.1.3"
   checksum: 10c0/8424f60f6bf8694cfd2a9bca45845bce29f26105cda8cf19cdb9fd3e78dc6338699e4db77a89ae449260bafa1cc6bec307e81e7fb96dbf7dcfce0eea55151356
   languageName: node
   linkType: hard
 
 "@swc/types@npm:^0.1.25":
   version: 0.1.25
-  resolution: "@swc/types@npm:0.1.25::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40swc%2Ftypes%2F-%2Ftypes-0.1.25.tgz"
+  resolution: "@swc/types@npm:0.1.25"
   dependencies:
     "@swc/counter": "npm:^0.1.3"
   checksum: 10c0/847a5b20b131281f89d640a7ed4887fb65724807d53d334b230e84b98c21097aa10cd28a074f9ed287a6ce109e443dd4bafbe7dcfb62333d7806c4ea3e7f8aca
@@ -2777,42 +2777,42 @@ __metadata:
 
 "@tootallnate/once@npm:2":
   version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40tootallnate%2Fonce%2F-%2Fonce-2.0.0.tgz"
+  resolution: "@tootallnate/once@npm:2.0.0"
   checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
   languageName: node
   linkType: hard
 
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.12
-  resolution: "@tsconfig/node10@npm:1.0.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40tsconfig%2Fnode10%2F-%2Fnode10-1.0.12.tgz"
+  resolution: "@tsconfig/node10@npm:1.0.12"
   checksum: 10c0/7bbbd7408cfaced86387a9b1b71cebc91c6fd701a120369735734da8eab1a4773fc079abd9f40c9e0b049e12586c8ac0e13f0da596bfd455b9b4c3faa813ebc5
   languageName: node
   linkType: hard
 
 "@tsconfig/node12@npm:^1.0.7":
   version: 1.0.11
-  resolution: "@tsconfig/node12@npm:1.0.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40tsconfig%2Fnode12%2F-%2Fnode12-1.0.11.tgz"
+  resolution: "@tsconfig/node12@npm:1.0.11"
   checksum: 10c0/dddca2b553e2bee1308a056705103fc8304e42bb2d2cbd797b84403a223b25c78f2c683ec3e24a095e82cd435387c877239bffcb15a590ba817cd3f6b9a99fd9
   languageName: node
   linkType: hard
 
 "@tsconfig/node14@npm:^1.0.0":
   version: 1.0.3
-  resolution: "@tsconfig/node14@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40tsconfig%2Fnode14%2F-%2Fnode14-1.0.3.tgz"
+  resolution: "@tsconfig/node14@npm:1.0.3"
   checksum: 10c0/67c1316d065fdaa32525bc9449ff82c197c4c19092b9663b23213c8cbbf8d88b6ed6a17898e0cbc2711950fbfaf40388938c1c748a2ee89f7234fc9e7fe2bf44
   languageName: node
   linkType: hard
 
 "@tsconfig/node16@npm:^1.0.2":
   version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40tsconfig%2Fnode16%2F-%2Fnode16-1.0.4.tgz"
+  resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 10c0/05f8f2734e266fb1839eb1d57290df1664fe2aa3b0fdd685a9035806daa635f7519bf6d5d9b33f6e69dd545b8c46bd6e2b5c79acb2b1f146e885f7f11a42a5bb
   languageName: node
   linkType: hard
 
 "@tybys/wasm-util@npm:^0.10.1":
   version: 0.10.1
-  resolution: "@tybys/wasm-util@npm:0.10.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40tybys%2Fwasm-util%2F-%2Fwasm-util-0.10.1.tgz"
+  resolution: "@tybys/wasm-util@npm:0.10.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
@@ -2821,7 +2821,7 @@ __metadata:
 
 "@types/autoprefixer@npm:^9.7.2":
   version: 9.7.2
-  resolution: "@types/autoprefixer@npm:9.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fautoprefixer%2F-%2Fautoprefixer-9.7.2.tgz"
+  resolution: "@types/autoprefixer@npm:9.7.2"
   dependencies:
     "@types/browserslist": "npm:*"
     postcss: "npm:7.x.x"
@@ -2831,7 +2831,7 @@ __metadata:
 
 "@types/body-parser@npm:*":
   version: 1.19.6
-  resolution: "@types/body-parser@npm:1.19.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fbody-parser%2F-%2Fbody-parser-1.19.6.tgz"
+  resolution: "@types/body-parser@npm:1.19.6"
   dependencies:
     "@types/connect": "npm:*"
     "@types/node": "npm:*"
@@ -2841,21 +2841,21 @@ __metadata:
 
 "@types/browserslist@npm:*":
   version: 4.8.0
-  resolution: "@types/browserslist@npm:4.8.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fbrowserslist%2F-%2Fbrowserslist-4.8.0.tgz"
+  resolution: "@types/browserslist@npm:4.8.0"
   checksum: 10c0/827982532ee80cfc58405e04eba7e310dd98ba107274c3c058dfdcddcb924e209ffee59ee18846d45005d2a6515b62310328e1c29ec826c2ba3c82cb567c769c
   languageName: node
   linkType: hard
 
 "@types/caseless@npm:*":
   version: 0.12.5
-  resolution: "@types/caseless@npm:0.12.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fcaseless%2F-%2Fcaseless-0.12.5.tgz"
+  resolution: "@types/caseless@npm:0.12.5"
   checksum: 10c0/b1f8b8a38ce747b643115d37a40ea824c658bd7050e4b69427a10e9d12d1606ed17a0f6018241c08291cd59f70aeb3c1f3754ad61e45f8dbba708ec72dde7ec8
   languageName: node
   linkType: hard
 
 "@types/chai@npm:^5.2.2":
   version: 5.2.3
-  resolution: "@types/chai@npm:5.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fchai%2F-%2Fchai-5.2.3.tgz"
+  resolution: "@types/chai@npm:5.2.3"
   dependencies:
     "@types/deep-eql": "npm:*"
     assertion-error: "npm:^2.0.1"
@@ -2865,7 +2865,7 @@ __metadata:
 
 "@types/connect@npm:*, @types/connect@npm:3.4.38":
   version: 3.4.38
-  resolution: "@types/connect@npm:3.4.38::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fconnect%2F-%2Fconnect-3.4.38.tgz"
+  resolution: "@types/connect@npm:3.4.38"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/2e1cdba2c410f25649e77856505cd60223250fa12dff7a503e492208dbfdd25f62859918f28aba95315251fd1f5e1ffbfca1e25e73037189ab85dd3f8d0a148c
@@ -2874,7 +2874,7 @@ __metadata:
 
 "@types/cors@npm:^2.8.12":
   version: 2.8.19
-  resolution: "@types/cors@npm:2.8.19::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fcors%2F-%2Fcors-2.8.19.tgz"
+  resolution: "@types/cors@npm:2.8.19"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/b5dd407040db7d8aa1bd36e79e5f3f32292f6b075abc287529e9f48df1a25fda3e3799ba30b4656667ffb931d3b75690c1d6ca71e39f7337ea6dfda8581916d0
@@ -2883,7 +2883,7 @@ __metadata:
 
 "@types/csurf@npm:*":
   version: 1.11.5
-  resolution: "@types/csurf@npm:1.11.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fcsurf%2F-%2Fcsurf-1.11.5.tgz"
+  resolution: "@types/csurf@npm:1.11.5"
   dependencies:
     "@types/express-serve-static-core": "npm:*"
   checksum: 10c0/f1d831f5ffe5ed6f9fad71f1ca8ac68e464625d6ff1c229f2761e392b92888d6fa83209a4dd451f9923b55142f8a7b9945b77d26f9252db409d823a1358d2155
@@ -2892,7 +2892,7 @@ __metadata:
 
 "@types/debug@npm:^4.1.12":
   version: 4.1.12
-  resolution: "@types/debug@npm:4.1.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fdebug%2F-%2Fdebug-4.1.12.tgz"
+  resolution: "@types/debug@npm:4.1.12"
   dependencies:
     "@types/ms": "npm:*"
   checksum: 10c0/5dcd465edbb5a7f226e9a5efd1f399c6172407ef5840686b73e3608ce135eeca54ae8037dcd9f16bdb2768ac74925b820a8b9ecc588a58ca09eca6acabe33e2f
@@ -2901,14 +2901,14 @@ __metadata:
 
 "@types/deep-eql@npm:*":
   version: 4.0.2
-  resolution: "@types/deep-eql@npm:4.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fdeep-eql%2F-%2Fdeep-eql-4.0.2.tgz"
+  resolution: "@types/deep-eql@npm:4.0.2"
   checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
   languageName: node
   linkType: hard
 
 "@types/escape-string-regexp@npm:^2.0.3":
   version: 2.0.3
-  resolution: "@types/escape-string-regexp@npm:2.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fescape-string-regexp%2F-%2Fescape-string-regexp-2.0.3.tgz"
+  resolution: "@types/escape-string-regexp@npm:2.0.3"
   dependencies:
     escape-string-regexp: "npm:*"
   checksum: 10c0/af1fbfdadafb7c3bcce40389b739172ff46c408f5d46ef9528952f82267ac5ecd619870f8fab82c034ae85bfb882af0f515a24ad6d9575629593a93d5801a3b7
@@ -2917,21 +2917,21 @@ __metadata:
 
 "@types/estree@npm:1.0.5":
   version: 1.0.5
-  resolution: "@types/estree@npm:1.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Festree%2F-%2Festree-1.0.5.tgz"
+  resolution: "@types/estree@npm:1.0.5"
   checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
   languageName: node
   linkType: hard
 
 "@types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.1, @types/estree@npm:^1.0.6":
   version: 1.0.8
-  resolution: "@types/estree@npm:1.0.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Festree%2F-%2Festree-1.0.8.tgz"
+  resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
 "@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:^5.0.0":
   version: 5.1.1
-  resolution: "@types/express-serve-static-core@npm:5.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fexpress-serve-static-core%2F-%2Fexpress-serve-static-core-5.1.1.tgz"
+  resolution: "@types/express-serve-static-core@npm:5.1.1"
   dependencies:
     "@types/node": "npm:*"
     "@types/qs": "npm:*"
@@ -2943,7 +2943,7 @@ __metadata:
 
 "@types/express-session@npm:*":
   version: 1.18.2
-  resolution: "@types/express-session@npm:1.18.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fexpress-session%2F-%2Fexpress-session-1.18.2.tgz"
+  resolution: "@types/express-session@npm:1.18.2"
   dependencies:
     "@types/express": "npm:*"
   checksum: 10c0/5d5aa134ce8990920b35f2dd0aa55168af44faaf14789b6921d361ce016c43bdc66feba287753981a2fee33fd95b8a829c4418c3ca480b03961724b8bc13e453
@@ -2952,7 +2952,7 @@ __metadata:
 
 "@types/express@npm:*":
   version: 5.0.6
-  resolution: "@types/express@npm:5.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fexpress%2F-%2Fexpress-5.0.6.tgz"
+  resolution: "@types/express@npm:5.0.6"
   dependencies:
     "@types/body-parser": "npm:*"
     "@types/express-serve-static-core": "npm:^5.0.0"
@@ -2963,7 +2963,7 @@ __metadata:
 
 "@types/formidable@npm:*":
   version: 3.5.0
-  resolution: "@types/formidable@npm:3.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fformidable%2F-%2Fformidable-3.5.0.tgz"
+  resolution: "@types/formidable@npm:3.5.0"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/6e6b70a6f80f29f053a5e11a1277ce23c5491079897cb9b1c2c1cf403f6b0590ab1bd8f7fce45bddb14366414e3291c8b8ab1ccb688237448e350effb939c4f3
@@ -2972,7 +2972,7 @@ __metadata:
 
 "@types/helmet@npm:0.0.48":
   version: 0.0.48
-  resolution: "@types/helmet@npm:0.0.48::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fhelmet%2F-%2Fhelmet-0.0.48.tgz"
+  resolution: "@types/helmet@npm:0.0.48"
   dependencies:
     "@types/express": "npm:*"
   checksum: 10c0/37d4171a92a109e83ad0510249bd4e5cad39ea11d4a4adb19480c3fe7a0a473c29d77363d3753afa7d72deefccd287a0f6867a9fec7d07a3c3b2993feecece38
@@ -2981,14 +2981,14 @@ __metadata:
 
 "@types/http-errors@npm:*":
   version: 2.0.5
-  resolution: "@types/http-errors@npm:2.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fhttp-errors%2F-%2Fhttp-errors-2.0.5.tgz"
+  resolution: "@types/http-errors@npm:2.0.5"
   checksum: 10c0/00f8140fbc504f47356512bd88e1910c2f07e04233d99c88c854b3600ce0523c8cd0ba7d1897667243282eb44c59abb9245959e2428b9de004f93937f52f7c15
   languageName: node
   linkType: hard
 
 "@types/jsonwebtoken@npm:^9.0.4":
   version: 9.0.10
-  resolution: "@types/jsonwebtoken@npm:9.0.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fjsonwebtoken%2F-%2Fjsonwebtoken-9.0.10.tgz"
+  resolution: "@types/jsonwebtoken@npm:9.0.10"
   dependencies:
     "@types/ms": "npm:*"
     "@types/node": "npm:*"
@@ -2998,28 +2998,28 @@ __metadata:
 
 "@types/lodash@npm:^4.17.13":
   version: 4.17.23
-  resolution: "@types/lodash@npm:4.17.23::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Flodash%2F-%2Flodash-4.17.23.tgz"
+  resolution: "@types/lodash@npm:4.17.23"
   checksum: 10c0/9d9cbfb684e064a2b78aab9e220d398c9c2a7d36bc51a07b184ff382fa043a99b3d00c16c7f109b4eb8614118f4869678dbae7d5c6700ed16fb9340e26cc0bf6
   languageName: node
   linkType: hard
 
 "@types/long@npm:^4.0.0":
   version: 4.0.2
-  resolution: "@types/long@npm:4.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Flong%2F-%2Flong-4.0.2.tgz"
+  resolution: "@types/long@npm:4.0.2"
   checksum: 10c0/42ec66ade1f72ff9d143c5a519a65efc7c1c77be7b1ac5455c530ae9acd87baba065542f8847522af2e3ace2cc999f3ad464ef86e6b7352eece34daf88f8c924
   languageName: node
   linkType: hard
 
 "@types/ms@npm:*":
   version: 2.1.0
-  resolution: "@types/ms@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fms%2F-%2Fms-2.1.0.tgz"
+  resolution: "@types/ms@npm:2.1.0"
   checksum: 10c0/5ce692ffe1549e1b827d99ef8ff71187457e0eb44adbae38fdf7b9a74bae8d20642ee963c14516db1d35fa2652e65f47680fdf679dcbde52bbfadd021f497225
   languageName: node
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:>=13.7.0":
   version: 25.0.9
-  resolution: "@types/node@npm:25.0.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnode%2F-%2Fnode-25.0.9.tgz"
+  resolution: "@types/node@npm:25.0.9"
   dependencies:
     undici-types: "npm:~7.16.0"
   checksum: 10c0/a757efafe303d9c8833eb53c2e9a0981cd5ac725cdc04c5612a71db86468c938778d4fa328be4231b68fffc68258638764df7b9c69e86cf55f0bb67105eb056f
@@ -3028,14 +3028,14 @@ __metadata:
 
 "@types/node@npm:^12.7.1":
   version: 12.20.55
-  resolution: "@types/node@npm:12.20.55::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnode%2F-%2Fnode-12.20.55.tgz"
+  resolution: "@types/node@npm:12.20.55"
   checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
   languageName: node
   linkType: hard
 
 "@types/node@npm:^22.8.7":
   version: 22.19.7
-  resolution: "@types/node@npm:22.19.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnode%2F-%2Fnode-22.19.7.tgz"
+  resolution: "@types/node@npm:22.19.7"
   dependencies:
     undici-types: "npm:~6.21.0"
   checksum: 10c0/0a4b13fd51306a72393f145693063e074be1bf884bdc642c879436d2c053ac9d573cc0a0d69867f60b14d3f1b9d03317e8ec0e4377f7527cb645e7b2a5d34045
@@ -3044,7 +3044,7 @@ __metadata:
 
 "@types/node@npm:^24.9.2":
   version: 24.10.9
-  resolution: "@types/node@npm:24.10.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnode%2F-%2Fnode-24.10.9.tgz"
+  resolution: "@types/node@npm:24.10.9"
   dependencies:
     undici-types: "npm:~7.16.0"
   checksum: 10c0/e9e436fcd2136bddb1bbe3271a89f4653910bcf6ee8047c4117f544c7905a106c039e2720ee48f28505ef2560e22fb9ead719f28bf5e075fdde0c1120e38e3b2
@@ -3053,14 +3053,14 @@ __metadata:
 
 "@types/normalize-package-data@npm:^2.4.3":
   version: 2.4.4
-  resolution: "@types/normalize-package-data@npm:2.4.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnormalize-package-data%2F-%2Fnormalize-package-data-2.4.4.tgz"
+  resolution: "@types/normalize-package-data@npm:2.4.4"
   checksum: 10c0/aef7bb9b015883d6f4119c423dd28c4bdc17b0e8a0ccf112c78b4fe0e91fbc4af7c6204b04bba0e199a57d2f3fbbd5b4a14bf8739bf9d2a39b2a0aad545e0f86
   languageName: node
   linkType: hard
 
 "@types/pify@npm:^6.1.0":
   version: 6.1.0
-  resolution: "@types/pify@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fpify%2F-%2Fpify-6.1.0.tgz"
+  resolution: "@types/pify@npm:6.1.0"
   dependencies:
     pify: "npm:*"
   checksum: 10c0/3b3460b207701d5ab3beafcbf8188988515982cd9c01c95ae8b70edf36e7b37ea9cca7cd44035e32e80189e100320497e999372c4de9b2376842df593aa9c331
@@ -3069,21 +3069,21 @@ __metadata:
 
 "@types/qs@npm:*":
   version: 6.15.0
-  resolution: "@types/qs@npm:6.15.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fqs%2F-%2Fqs-6.15.0.tgz"
+  resolution: "@types/qs@npm:6.15.0"
   checksum: 10c0/1b104cac50e655fc41d7fc1de2c2aba2908c4cf833a555b6808fb4c96752662b439238f2392a15d2590a7a6ca75dbd40e42d9378ac2be0d548ee484954363688
   languageName: node
   linkType: hard
 
 "@types/range-parser@npm:*":
   version: 1.2.7
-  resolution: "@types/range-parser@npm:1.2.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Frange-parser%2F-%2Frange-parser-1.2.7.tgz"
+  resolution: "@types/range-parser@npm:1.2.7"
   checksum: 10c0/361bb3e964ec5133fa40644a0b942279ed5df1949f21321d77de79f48b728d39253e5ce0408c9c17e4e0fd95ca7899da36841686393b9f7a1e209916e9381a3c
   languageName: node
   linkType: hard
 
 "@types/request@npm:^2.48.8":
   version: 2.48.13
-  resolution: "@types/request@npm:2.48.13::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Frequest%2F-%2Frequest-2.48.13.tgz"
+  resolution: "@types/request@npm:2.48.13"
   dependencies:
     "@types/caseless": "npm:*"
     "@types/node": "npm:*"
@@ -3095,7 +3095,7 @@ __metadata:
 
 "@types/rimraf@npm:^4.0.5":
   version: 4.0.5
-  resolution: "@types/rimraf@npm:4.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Frimraf%2F-%2Frimraf-4.0.5.tgz"
+  resolution: "@types/rimraf@npm:4.0.5"
   dependencies:
     rimraf: "npm:*"
   checksum: 10c0/b4c17f5931ab7f7610c68aba58024717eecd11d16057b51d3f21a4180d36d1f5fea207503cba8a13749d61a1ac43d1bb795662f8b3638ad2501216017d232bf6
@@ -3104,7 +3104,7 @@ __metadata:
 
 "@types/sanitize-filename@npm:^1.6.3":
   version: 1.6.3
-  resolution: "@types/sanitize-filename@npm:1.6.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fsanitize-filename%2F-%2Fsanitize-filename-1.6.3.tgz"
+  resolution: "@types/sanitize-filename@npm:1.6.3"
   dependencies:
     sanitize-filename: "npm:*"
   checksum: 10c0/e06135549ff3ce83b1cc5035517264435c33f5bdd1759dbd9041f8d4aff47c2141a17fd273e39b0d9f816cb5b3b74e3a72981be1503723c87eace9a1d80fb245
@@ -3113,14 +3113,14 @@ __metadata:
 
 "@types/semver@npm:^7":
   version: 7.7.1
-  resolution: "@types/semver@npm:7.7.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fsemver%2F-%2Fsemver-7.7.1.tgz"
+  resolution: "@types/semver@npm:7.7.1"
   checksum: 10c0/c938aef3bf79a73f0f3f6037c16e2e759ff40c54122ddf0b2583703393d8d3127130823facb880e694caa324eb6845628186aac1997ee8b31dc2d18fafe26268
   languageName: node
   linkType: hard
 
 "@types/send@npm:*":
   version: 1.2.1
-  resolution: "@types/send@npm:1.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fsend%2F-%2Fsend-1.2.1.tgz"
+  resolution: "@types/send@npm:1.2.1"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/7673747f8c2d8e67f3b1b3b57e9d4d681801a4f7b526ecf09987bb9a84a61cf94aa411c736183884dc762c1c402a61681eb1ef200d8d45d7e5ec0ab67ea5f6c1
@@ -3129,7 +3129,7 @@ __metadata:
 
 "@types/serve-static@npm:^2":
   version: 2.2.0
-  resolution: "@types/serve-static@npm:2.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fserve-static%2F-%2Fserve-static-2.2.0.tgz"
+  resolution: "@types/serve-static@npm:2.2.0"
   dependencies:
     "@types/http-errors": "npm:*"
     "@types/node": "npm:*"
@@ -3139,7 +3139,7 @@ __metadata:
 
 "@types/server@npm:^1":
   version: 1.0.11
-  resolution: "@types/server@npm:1.0.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fserver%2F-%2Fserver-1.0.11.tgz"
+  resolution: "@types/server@npm:1.0.11"
   dependencies:
     "@types/body-parser": "npm:*"
     "@types/csurf": "npm:*"
@@ -3153,21 +3153,21 @@ __metadata:
 
 "@types/strip-bom@npm:^3.0.0":
   version: 3.0.0
-  resolution: "@types/strip-bom@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fstrip-bom%2F-%2Fstrip-bom-3.0.0.tgz"
+  resolution: "@types/strip-bom@npm:3.0.0"
   checksum: 10c0/6638635fb52dc1f7a4aa596445170ffc731f3bea307d25d79709dcce14f80870128a6f0304032863b9d1a86b4b5f45d48bcaf96abe81f42e61f0a3eb18a1b996
   languageName: node
   linkType: hard
 
 "@types/strip-json-comments@npm:0.0.30":
   version: 0.0.30
-  resolution: "@types/strip-json-comments@npm:0.0.30::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fstrip-json-comments%2F-%2Fstrip-json-comments-0.0.30.tgz"
+  resolution: "@types/strip-json-comments@npm:0.0.30"
   checksum: 10c0/90509e345ac16c79f7aa7d7ef52e388e5be923f3456cf8052d36ee0eb4abc5ec4080c5f010f78cf01f5599546577eb3724256bc698663e86f0fe08a5a3fb7f68
   languageName: node
   linkType: hard
 
 "@types/tapable@npm:2.2.7":
   version: 2.2.7
-  resolution: "@types/tapable@npm:2.2.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Ftapable%2F-%2Ftapable-2.2.7.tgz"
+  resolution: "@types/tapable@npm:2.2.7"
   dependencies:
     tapable: "npm:^2.2.0"
   checksum: 10c0/112e4e94588edfcb597c8161185c6b7cae1ea780c7bf3e8fe41d5c88a283447518939a890df139e6a46d9abddce670cad40cf07145ea9b792bad8a3f17cfb5f2
@@ -3176,21 +3176,21 @@ __metadata:
 
 "@types/tough-cookie@npm:*":
   version: 4.0.5
-  resolution: "@types/tough-cookie@npm:4.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Ftough-cookie%2F-%2Ftough-cookie-4.0.5.tgz"
+  resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
   languageName: node
   linkType: hard
 
 "@types/yargs-parser@npm:*":
   version: 21.0.3
-  resolution: "@types/yargs-parser@npm:21.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fyargs-parser%2F-%2Fyargs-parser-21.0.3.tgz"
+  resolution: "@types/yargs-parser@npm:21.0.3"
   checksum: 10c0/e71c3bd9d0b73ca82e10bee2064c384ab70f61034bbfb78e74f5206283fc16a6d85267b606b5c22cb2a3338373586786fed595b2009825d6a9115afba36560a0
   languageName: node
   linkType: hard
 
 "@types/yargs@npm:^17.0.34":
   version: 17.0.35
-  resolution: "@types/yargs@npm:17.0.35::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fyargs%2F-%2Fyargs-17.0.35.tgz"
+  resolution: "@types/yargs@npm:17.0.35"
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 10c0/609557826a6b85e73ccf587923f6429850d6dc70e420b455bab4601b670bfadf684b09ae288bccedab042c48ba65f1666133cf375814204b544009f57d6eef63
@@ -3199,7 +3199,7 @@ __metadata:
 
 "@vitest/coverage-v8@npm:^4.0.6":
   version: 4.0.17
-  resolution: "@vitest/coverage-v8@npm:4.0.17::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fcoverage-v8%2F-%2Fcoverage-v8-4.0.17.tgz"
+  resolution: "@vitest/coverage-v8@npm:4.0.17"
   dependencies:
     "@bcoe/v8-coverage": "npm:^1.0.2"
     "@vitest/utils": "npm:4.0.17"
@@ -3223,7 +3223,7 @@ __metadata:
 
 "@vitest/expect@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/expect@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fexpect%2F-%2Fexpect-4.0.6.tgz"
+  resolution: "@vitest/expect@npm:4.0.6"
   dependencies:
     "@standard-schema/spec": "npm:^1.0.0"
     "@types/chai": "npm:^5.2.2"
@@ -3237,7 +3237,7 @@ __metadata:
 
 "@vitest/mocker@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/mocker@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fmocker%2F-%2Fmocker-4.0.6.tgz"
+  resolution: "@vitest/mocker@npm:4.0.6"
   dependencies:
     "@vitest/spy": "npm:4.0.6"
     estree-walker: "npm:^3.0.3"
@@ -3256,7 +3256,7 @@ __metadata:
 
 "@vitest/pretty-format@npm:4.0.17":
   version: 4.0.17
-  resolution: "@vitest/pretty-format@npm:4.0.17::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fpretty-format%2F-%2Fpretty-format-4.0.17.tgz"
+  resolution: "@vitest/pretty-format@npm:4.0.17"
   dependencies:
     tinyrainbow: "npm:^3.0.3"
   checksum: 10c0/10a2dd7e2daf7ee006107d380bbd28b66b09a7014d31087daab0dea7dee0d12868cfcf6b3372729268502fd9065162345b68b9b9c5d225f5c6c2fd2c664a2a86
@@ -3265,7 +3265,7 @@ __metadata:
 
 "@vitest/pretty-format@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/pretty-format@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fpretty-format%2F-%2Fpretty-format-4.0.6.tgz"
+  resolution: "@vitest/pretty-format@npm:4.0.6"
   dependencies:
     tinyrainbow: "npm:^3.0.3"
   checksum: 10c0/e7dba3ca676d3a14d9c8bf8042c3cf40d1f77060dfe0426dfd6ed531416b7a85dfc97326d1d475b44718899f96352b4014ec85cb6ea72415fcd157ccea680286
@@ -3274,7 +3274,7 @@ __metadata:
 
 "@vitest/runner@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/runner@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Frunner%2F-%2Frunner-4.0.6.tgz"
+  resolution: "@vitest/runner@npm:4.0.6"
   dependencies:
     "@vitest/utils": "npm:4.0.6"
     pathe: "npm:^2.0.3"
@@ -3284,7 +3284,7 @@ __metadata:
 
 "@vitest/snapshot@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/snapshot@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fsnapshot%2F-%2Fsnapshot-4.0.6.tgz"
+  resolution: "@vitest/snapshot@npm:4.0.6"
   dependencies:
     "@vitest/pretty-format": "npm:4.0.6"
     magic-string: "npm:^0.30.19"
@@ -3295,14 +3295,14 @@ __metadata:
 
 "@vitest/spy@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/spy@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fspy%2F-%2Fspy-4.0.6.tgz"
+  resolution: "@vitest/spy@npm:4.0.6"
   checksum: 10c0/d4a1837a53e90c7fe469079e6ffaef9def7fb3fbb80cbac4b3a79a93f76bf25948affd223e609527d2a3083992b974267cf0141376754c6d961baaa5bbe3d26e
   languageName: node
   linkType: hard
 
 "@vitest/ui@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/ui@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Fui%2F-%2Fui-4.0.6.tgz"
+  resolution: "@vitest/ui@npm:4.0.6"
   dependencies:
     "@vitest/utils": "npm:4.0.6"
     fflate: "npm:^0.8.2"
@@ -3319,7 +3319,7 @@ __metadata:
 
 "@vitest/utils@npm:4.0.17":
   version: 4.0.17
-  resolution: "@vitest/utils@npm:4.0.17::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Futils%2F-%2Futils-4.0.17.tgz"
+  resolution: "@vitest/utils@npm:4.0.17"
   dependencies:
     "@vitest/pretty-format": "npm:4.0.17"
     tinyrainbow: "npm:^3.0.3"
@@ -3329,7 +3329,7 @@ __metadata:
 
 "@vitest/utils@npm:4.0.6":
   version: 4.0.6
-  resolution: "@vitest/utils@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40vitest%2Futils%2F-%2Futils-4.0.6.tgz"
+  resolution: "@vitest/utils@npm:4.0.6"
   dependencies:
     "@vitest/pretty-format": "npm:4.0.6"
     tinyrainbow: "npm:^3.0.3"
@@ -3339,14 +3339,14 @@ __metadata:
 
 "abbrev@npm:^4.0.0":
   version: 4.0.0
-  resolution: "abbrev@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fabbrev%2F-%2Fabbrev-4.0.0.tgz"
+  resolution: "abbrev@npm:4.0.0"
   checksum: 10c0/b4cc16935235e80702fc90192e349e32f8ef0ed151ef506aa78c81a7c455ec18375c4125414b99f84b2e055199d66383e787675f0bcd87da7a4dbd59f9eac1d5
   languageName: node
   linkType: hard
 
 "abort-controller@npm:^3.0.0":
   version: 3.0.0
-  resolution: "abort-controller@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fabort-controller%2F-%2Fabort-controller-3.0.0.tgz"
+  resolution: "abort-controller@npm:3.0.0"
   dependencies:
     event-target-shim: "npm:^5.0.0"
   checksum: 10c0/90ccc50f010250152509a344eb2e71977fbf8db0ab8f1061197e3275ddf6c61a41a6edfd7b9409c664513131dd96e962065415325ef23efa5db931b382d24ca5
@@ -3355,7 +3355,7 @@ __metadata:
 
 "accepts@npm:~1.3.4, accepts@npm:~1.3.8":
   version: 1.3.8
-  resolution: "accepts@npm:1.3.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Faccepts%2F-%2Faccepts-1.3.8.tgz"
+  resolution: "accepts@npm:1.3.8"
   dependencies:
     mime-types: "npm:~2.1.34"
     negotiator: "npm:0.6.3"
@@ -3365,7 +3365,7 @@ __metadata:
 
 "acorn-import-attributes@npm:^1.9.5":
   version: 1.9.5
-  resolution: "acorn-import-attributes@npm:1.9.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Facorn-import-attributes%2F-%2Facorn-import-attributes-1.9.5.tgz"
+  resolution: "acorn-import-attributes@npm:1.9.5"
   peerDependencies:
     acorn: ^8
   checksum: 10c0/5926eaaead2326d5a86f322ff1b617b0f698aa61dc719a5baa0e9d955c9885cc71febac3fb5bacff71bbf2c4f9c12db2056883c68c53eb962c048b952e1e013d
@@ -3374,7 +3374,7 @@ __metadata:
 
 "acorn-walk@npm:8.3.4, acorn-walk@npm:^8.1.1":
   version: 8.3.4
-  resolution: "acorn-walk@npm:8.3.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Facorn-walk%2F-%2Facorn-walk-8.3.4.tgz"
+  resolution: "acorn-walk@npm:8.3.4"
   dependencies:
     acorn: "npm:^8.11.0"
   checksum: 10c0/76537ac5fb2c37a64560feaf3342023dadc086c46da57da363e64c6148dc21b57d49ace26f949e225063acb6fb441eabffd89f7a3066de5ad37ab3e328927c62
@@ -3383,7 +3383,7 @@ __metadata:
 
 "acorn@npm:^7.1.1":
   version: 7.4.1
-  resolution: "acorn@npm:7.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Facorn%2F-%2Facorn-7.4.1.tgz"
+  resolution: "acorn@npm:7.4.1"
   bin:
     acorn: bin/acorn
   checksum: 10c0/bd0b2c2b0f334bbee48828ff897c12bd2eb5898d03bf556dcc8942022cec795ac5bb5b6b585e2de687db6231faf07e096b59a361231dd8c9344d5df5f7f0e526
@@ -3392,7 +3392,7 @@ __metadata:
 
 "acorn@npm:^8.10.0, acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.4.1, acorn@npm:^8.9.0":
   version: 8.15.0
-  resolution: "acorn@npm:8.15.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Facorn%2F-%2Facorn-8.15.0.tgz"
+  resolution: "acorn@npm:8.15.0"
   bin:
     acorn: bin/acorn
   checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
@@ -3401,7 +3401,7 @@ __metadata:
 
 "agent-base@npm:6":
   version: 6.0.2
-  resolution: "agent-base@npm:6.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fagent-base%2F-%2Fagent-base-6.0.2.tgz"
+  resolution: "agent-base@npm:6.0.2"
   dependencies:
     debug: "npm:4"
   checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
@@ -3410,14 +3410,14 @@ __metadata:
 
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
-  resolution: "agent-base@npm:7.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fagent-base%2F-%2Fagent-base-7.1.4.tgz"
+  resolution: "agent-base@npm:7.1.4"
   checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
   languageName: node
   linkType: hard
 
 "ansi-align@npm:^3.0.1":
   version: 3.0.1
-  resolution: "ansi-align@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-align%2F-%2Fansi-align-3.0.1.tgz"
+  resolution: "ansi-align@npm:3.0.1"
   dependencies:
     string-width: "npm:^4.1.0"
   checksum: 10c0/ad8b755a253a1bc8234eb341e0cec68a857ab18bf97ba2bda529e86f6e30460416523e0ec58c32e5c21f0ca470d779503244892873a5895dbd0c39c788e82467
@@ -3426,21 +3426,21 @@ __metadata:
 
 "ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-colors%2F-%2Fansi-colors-4.1.3.tgz"
+  resolution: "ansi-colors@npm:4.1.3"
   checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
   languageName: node
   linkType: hard
 
 "ansi-escapes@npm:^3.0.0, ansi-escapes@npm:^3.2.0":
   version: 3.2.0
-  resolution: "ansi-escapes@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-escapes%2F-%2Fansi-escapes-3.2.0.tgz"
+  resolution: "ansi-escapes@npm:3.2.0"
   checksum: 10c0/084e1ce38139ad2406f18a8e7efe2b850ddd06ce3c00f633392d1ce67756dab44fe290e573d09ef3c9a0cb13c12881e0e35a8f77a017d39a0a4ab85ae2fae04f
   languageName: node
   linkType: hard
 
 "ansi-escapes@npm:^4.2.1":
   version: 4.3.2
-  resolution: "ansi-escapes@npm:4.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-escapes%2F-%2Fansi-escapes-4.3.2.tgz"
+  resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
     type-fest: "npm:^0.21.3"
   checksum: 10c0/da917be01871525a3dfcf925ae2977bc59e8c513d4423368645634bf5d4ceba5401574eb705c1e92b79f7292af5a656f78c5725a4b0e1cec97c4b413705c1d50
@@ -3449,7 +3449,7 @@ __metadata:
 
 "ansi-escapes@npm:^5.0.0":
   version: 5.0.0
-  resolution: "ansi-escapes@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-escapes%2F-%2Fansi-escapes-5.0.0.tgz"
+  resolution: "ansi-escapes@npm:5.0.0"
   dependencies:
     type-fest: "npm:^1.0.2"
   checksum: 10c0/f705cc7fbabb981ddf51562cd950792807bccd7260cc3d9478a619dda62bff6634c87ca100f2545ac7aade9b72652c4edad8c7f0d31a0b949b5fa58f33eaf0d0
@@ -3458,49 +3458,49 @@ __metadata:
 
 "ansi-regex@npm:^2.0.0":
   version: 2.1.1
-  resolution: "ansi-regex@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-regex%2F-%2Fansi-regex-2.1.1.tgz"
+  resolution: "ansi-regex@npm:2.1.1"
   checksum: 10c0/78cebaf50bce2cb96341a7230adf28d804611da3ce6bf338efa7b72f06cc6ff648e29f80cd95e582617ba58d5fdbec38abfeed3500a98bce8381a9daec7c548b
   languageName: node
   linkType: hard
 
 "ansi-regex@npm:^3.0.0":
   version: 3.0.1
-  resolution: "ansi-regex@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-regex%2F-%2Fansi-regex-3.0.1.tgz"
+  resolution: "ansi-regex@npm:3.0.1"
   checksum: 10c0/d108a7498b8568caf4a46eea4f1784ab4e0dfb2e3f3938c697dee21443d622d765c958f2b7e2b9f6b9e55e2e2af0584eaa9915d51782b89a841c28e744e7a167
   languageName: node
   linkType: hard
 
 "ansi-regex@npm:^4.1.0":
   version: 4.1.1
-  resolution: "ansi-regex@npm:4.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-regex%2F-%2Fansi-regex-4.1.1.tgz"
+  resolution: "ansi-regex@npm:4.1.1"
   checksum: 10c0/d36d34234d077e8770169d980fed7b2f3724bfa2a01da150ccd75ef9707c80e883d27cdf7a0eac2f145ac1d10a785a8a855cffd05b85f778629a0db62e7033da
   languageName: node
   linkType: hard
 
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
-  resolution: "ansi-regex@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-regex%2F-%2Fansi-regex-5.0.1.tgz"
+  resolution: "ansi-regex@npm:5.0.1"
   checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
   languageName: node
   linkType: hard
 
 "ansi-regex@npm:^6.0.1":
   version: 6.2.2
-  resolution: "ansi-regex@npm:6.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-regex%2F-%2Fansi-regex-6.2.2.tgz"
+  resolution: "ansi-regex@npm:6.2.2"
   checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
   languageName: node
   linkType: hard
 
 "ansi-styles@npm:^2.2.1":
   version: 2.2.1
-  resolution: "ansi-styles@npm:2.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-styles%2F-%2Fansi-styles-2.2.1.tgz"
+  resolution: "ansi-styles@npm:2.2.1"
   checksum: 10c0/7c68aed4f1857389e7a12f85537ea5b40d832656babbf511cc7ecd9efc52889b9c3e5653a71a6aade783c3c5e0aa223ad4ff8e83c27ac8a666514e6c79068cab
   languageName: node
   linkType: hard
 
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
-  resolution: "ansi-styles@npm:3.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-styles%2F-%2Fansi-styles-3.2.1.tgz"
+  resolution: "ansi-styles@npm:3.2.1"
   dependencies:
     color-convert: "npm:^1.9.0"
   checksum: 10c0/ece5a8ef069fcc5298f67e3f4771a663129abd174ea2dfa87923a2be2abf6cd367ef72ac87942da00ce85bd1d651d4cd8595aebdb1b385889b89b205860e977b
@@ -3509,7 +3509,7 @@ __metadata:
 
 "ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
-  resolution: "ansi-styles@npm:4.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-styles%2F-%2Fansi-styles-4.3.0.tgz"
+  resolution: "ansi-styles@npm:4.3.0"
   dependencies:
     color-convert: "npm:^2.0.1"
   checksum: 10c0/895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
@@ -3518,28 +3518,28 @@ __metadata:
 
 "ansi-styles@npm:^6.2.1":
   version: 6.2.3
-  resolution: "ansi-styles@npm:6.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-styles%2F-%2Fansi-styles-6.2.3.tgz"
+  resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
   languageName: node
   linkType: hard
 
 "any-observable@npm:^0.3.0":
   version: 0.3.0
-  resolution: "any-observable@npm:0.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fany-observable%2F-%2Fany-observable-0.3.0.tgz"
+  resolution: "any-observable@npm:0.3.0"
   checksum: 10c0/104c2b79c2ac7e6c75b35f8fd62babf73015668f22bd25336c6f848350d91f9e7daf2fddbf1c1b76fe795e89fbc91b49f70a2aec5c69f1acf0562c344f36042b
   languageName: node
   linkType: hard
 
 "any-promise@npm:^1.0.0":
   version: 1.3.0
-  resolution: "any-promise@npm:1.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fany-promise%2F-%2Fany-promise-1.3.0.tgz"
+  resolution: "any-promise@npm:1.3.0"
   checksum: 10c0/60f0298ed34c74fef50daab88e8dab786036ed5a7fad02e012ab57e376e0a0b4b29e83b95ea9b5e7d89df762f5f25119b83e00706ecaccb22cfbacee98d74889
   languageName: node
   linkType: hard
 
 "anymatch@npm:~3.1.2":
   version: 3.1.3
-  resolution: "anymatch@npm:3.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fanymatch%2F-%2Fanymatch-3.1.3.tgz"
+  resolution: "anymatch@npm:3.1.3"
   dependencies:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
@@ -3549,35 +3549,35 @@ __metadata:
 
 "app-module-path@npm:^2.1.0":
   version: 2.2.0
-  resolution: "app-module-path@npm:2.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fapp-module-path%2F-%2Fapp-module-path-2.2.0.tgz"
+  resolution: "app-module-path@npm:2.2.0"
   checksum: 10c0/0d6d581dcee268271af1e611934b4fed715de55c382b2610de67ba6f87d01503fc0426cff687f06210e54cd57545f7a6172e1dd192914a3709ad89c06a4c3a0b
   languageName: node
   linkType: hard
 
 "aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.1.0
-  resolution: "aproba@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Faproba%2F-%2Faproba-2.1.0.tgz"
+  resolution: "aproba@npm:2.1.0"
   checksum: 10c0/ec8c1d351bac0717420c737eb062766fb63bde1552900e0f4fdad9eb064c3824fef23d1c416aa5f7a80f21ca682808e902d79b7c9ae756d342b5f1884f36932f
   languageName: node
   linkType: hard
 
 "are-we-there-yet@npm:^4.0.0":
   version: 4.0.2
-  resolution: "are-we-there-yet@npm:4.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fare-we-there-yet%2F-%2Fare-we-there-yet-4.0.2.tgz"
+  resolution: "are-we-there-yet@npm:4.0.2"
   checksum: 10c0/376204f6f07ee7a5f081f5043c92c4c39fd9984278486e0c7c60e74cfc61dc206d2363a2086610f6b95399d9dc3c193cec1832d0ce10666d567f64571c2dedf5
   languageName: node
   linkType: hard
 
 "arg@npm:^4.1.0":
   version: 4.1.3
-  resolution: "arg@npm:4.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Farg%2F-%2Farg-4.1.3.tgz"
+  resolution: "arg@npm:4.1.3"
   checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
   languageName: node
   linkType: hard
 
 "argparse@npm:^1.0.7":
   version: 1.0.10
-  resolution: "argparse@npm:1.0.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fargparse%2F-%2Fargparse-1.0.10.tgz"
+  resolution: "argparse@npm:1.0.10"
   dependencies:
     sprintf-js: "npm:~1.0.2"
   checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
@@ -3586,63 +3586,63 @@ __metadata:
 
 "argparse@npm:^2.0.1":
   version: 2.0.1
-  resolution: "argparse@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fargparse%2F-%2Fargparse-2.0.1.tgz"
+  resolution: "argparse@npm:2.0.1"
   checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
   languageName: node
   linkType: hard
 
 "aria-query@npm:^5.3.0":
   version: 5.3.2
-  resolution: "aria-query@npm:5.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Faria-query%2F-%2Faria-query-5.3.2.tgz"
+  resolution: "aria-query@npm:5.3.2"
   checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
   languageName: node
   linkType: hard
 
 "array-flatten@npm:1.1.1":
   version: 1.1.1
-  resolution: "array-flatten@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Farray-flatten%2F-%2Farray-flatten-1.1.1.tgz"
+  resolution: "array-flatten@npm:1.1.1"
   checksum: 10c0/806966c8abb2f858b08f5324d9d18d7737480610f3bd5d3498aaae6eb5efdc501a884ba019c9b4a8f02ff67002058749d05548fd42fa8643f02c9c7f22198b91
   languageName: node
   linkType: hard
 
 "array-union@npm:^2.1.0":
   version: 2.1.0
-  resolution: "array-union@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Farray-union%2F-%2Farray-union-2.1.0.tgz"
+  resolution: "array-union@npm:2.1.0"
   checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
   languageName: node
   linkType: hard
 
 "arrify@npm:^2.0.0":
   version: 2.0.1
-  resolution: "arrify@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Farrify%2F-%2Farrify-2.0.1.tgz"
+  resolution: "arrify@npm:2.0.1"
   checksum: 10c0/3fb30b5e7c37abea1907a60b28a554d2f0fc088757ca9bf5b684786e583fdf14360721eb12575c1ce6f995282eab936712d3c4389122682eafab0e0b57f78dbb
   languageName: node
   linkType: hard
 
 "asap@npm:^2.0.0, asap@npm:~2.0.3":
   version: 2.0.6
-  resolution: "asap@npm:2.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fasap%2F-%2Fasap-2.0.6.tgz"
+  resolution: "asap@npm:2.0.6"
   checksum: 10c0/c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
   languageName: node
   linkType: hard
 
 "assert-never@npm:^1.2.1":
   version: 1.4.0
-  resolution: "assert-never@npm:1.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fassert-never%2F-%2Fassert-never-1.4.0.tgz"
+  resolution: "assert-never@npm:1.4.0"
   checksum: 10c0/494db08b89fb43d6231c9b4c48da22824f1912d88992bf0268e43b3dad0f64bd56d380addbb997d2dea7d859421d5e2904e8bd01243794f2bb5bfbc8d32d1fc6
   languageName: node
   linkType: hard
 
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
-  resolution: "assertion-error@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fassertion-error%2F-%2Fassertion-error-2.0.1.tgz"
+  resolution: "assertion-error@npm:2.0.1"
   checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
 "ast-v8-to-istanbul@npm:^0.3.10":
   version: 0.3.10
-  resolution: "ast-v8-to-istanbul@npm:0.3.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fast-v8-to-istanbul%2F-%2Fast-v8-to-istanbul-0.3.10.tgz"
+  resolution: "ast-v8-to-istanbul@npm:0.3.10"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.31"
     estree-walker: "npm:^3.0.3"
@@ -3653,21 +3653,21 @@ __metadata:
 
 "async-function@npm:^1.0.0":
   version: 1.0.0
-  resolution: "async-function@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fasync-function%2F-%2Fasync-function-1.0.0.tgz"
+  resolution: "async-function@npm:1.0.0"
   checksum: 10c0/669a32c2cb7e45091330c680e92eaeb791bc1d4132d827591e499cd1f776ff5a873e77e5f92d0ce795a8d60f10761dec9ddfe7225a5de680f5d357f67b1aac73
   languageName: node
   linkType: hard
 
 "async-generator-function@npm:^1.0.0":
   version: 1.0.0
-  resolution: "async-generator-function@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fasync-generator-function%2F-%2Fasync-generator-function-1.0.0.tgz"
+  resolution: "async-generator-function@npm:1.0.0"
   checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
   languageName: node
   linkType: hard
 
 "async-retry@npm:^1.3.3":
   version: 1.3.3
-  resolution: "async-retry@npm:1.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fasync-retry%2F-%2Fasync-retry-1.3.3.tgz"
+  resolution: "async-retry@npm:1.3.3"
   dependencies:
     retry: "npm:0.13.1"
   checksum: 10c0/cabced4fb46f8737b95cc88dc9c0ff42656c62dc83ce0650864e891b6c155a063af08d62c446269b51256f6fbcb69a6563b80e76d0ea4a5117b0c0377b6b19d8
@@ -3676,14 +3676,14 @@ __metadata:
 
 "asynckit@npm:^0.4.0":
   version: 0.4.0
-  resolution: "asynckit@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fasynckit%2F-%2Fasynckit-0.4.0.tgz"
+  resolution: "asynckit@npm:0.4.0"
   checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
   languageName: node
   linkType: hard
 
 "atomically@npm:^2.0.3":
   version: 2.1.0
-  resolution: "atomically@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fatomically%2F-%2Fatomically-2.1.0.tgz"
+  resolution: "atomically@npm:2.1.0"
   dependencies:
     stubborn-fs: "npm:^2.0.0"
     when-exit: "npm:^2.1.4"
@@ -3693,7 +3693,7 @@ __metadata:
 
 "autoprefixer@npm:^9.7.6":
   version: 9.8.8
-  resolution: "autoprefixer@npm:9.8.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fautoprefixer%2F-%2Fautoprefixer-9.8.8.tgz"
+  resolution: "autoprefixer@npm:9.8.8"
   dependencies:
     browserslist: "npm:^4.12.0"
     caniuse-lite: "npm:^1.0.30001109"
@@ -3710,14 +3710,14 @@ __metadata:
 
 "axobject-query@npm:^4.0.0":
   version: 4.1.0
-  resolution: "axobject-query@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Faxobject-query%2F-%2Faxobject-query-4.1.0.tgz"
+  resolution: "axobject-query@npm:4.1.0"
   checksum: 10c0/c470e4f95008f232eadd755b018cb55f16c03ccf39c027b941cd8820ac6b68707ce5d7368a46756db4256fbc91bb4ead368f84f7fb034b2b7932f082f6dc0775
   languageName: node
   linkType: hard
 
 "babel-walk@npm:3.0.0-canary-5":
   version: 3.0.0-canary-5
-  resolution: "babel-walk@npm:3.0.0-canary-5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbabel-walk%2F-%2Fbabel-walk-3.0.0-canary-5.tgz"
+  resolution: "babel-walk@npm:3.0.0-canary-5"
   dependencies:
     "@babel/types": "npm:^7.9.6"
   checksum: 10c0/17b689874d15c37714cedf6797dd9321dcb998d8e0dda9a8fe8c8bbbf128bbdeb8935cf56e8630d6b67eae76d2a0bc1e470751e082c3b0e30b80d58beafb5e64
@@ -3726,28 +3726,28 @@ __metadata:
 
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbalanced-match%2F-%2Fbalanced-match-1.0.2.tgz"
+  resolution: "balanced-match@npm:1.0.2"
   checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
   languageName: node
   linkType: hard
 
 "base64-js@npm:^1.3.0":
   version: 1.5.1
-  resolution: "base64-js@npm:1.5.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbase64-js%2F-%2Fbase64-js-1.5.1.tgz"
+  resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
   languageName: node
   linkType: hard
 
 "base64id@npm:2.0.0, base64id@npm:~2.0.0":
   version: 2.0.0
-  resolution: "base64id@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbase64id%2F-%2Fbase64id-2.0.0.tgz"
+  resolution: "base64id@npm:2.0.0"
   checksum: 10c0/6919efd237ed44b9988cbfc33eca6f173a10e810ce50292b271a1a421aac7748ef232a64d1e6032b08f19aae48dce6ee8f66c5ae2c9e5066c82b884861d4d453
   languageName: node
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.9.0":
   version: 2.9.15
-  resolution: "baseline-browser-mapping@npm:2.9.15::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbaseline-browser-mapping%2F-%2Fbaseline-browser-mapping-2.9.15.tgz"
+  resolution: "baseline-browser-mapping@npm:2.9.15"
   bin:
     baseline-browser-mapping: dist/cli.js
   checksum: 10c0/e5c8cb8600fcbed8132f122b737b00b5b3fcf25a119ea5e42476e6d6b2263274ddc5df16d4cffebbcd46974b691008558973b06100508903ea8a382a5edd34ab
@@ -3756,14 +3756,14 @@ __metadata:
 
 "batch@npm:0.6.1":
   version: 0.6.1
-  resolution: "batch@npm:0.6.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbatch%2F-%2Fbatch-0.6.1.tgz"
+  resolution: "batch@npm:0.6.1"
   checksum: 10c0/925a13897b4db80d4211082fe287bcf96d297af38e26448c857cee3e095c9792e3b8f26b37d268812e7f38a589f694609de8534a018b1937d7dc9f84e6b387c5
   languageName: node
   linkType: hard
 
 "better-path-resolve@npm:1.0.0":
   version: 1.0.0
-  resolution: "better-path-resolve@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbetter-path-resolve%2F-%2Fbetter-path-resolve-1.0.0.tgz"
+  resolution: "better-path-resolve@npm:1.0.0"
   dependencies:
     is-windows: "npm:^1.0.0"
   checksum: 10c0/7335130729d59a14b8e4753fea180ca84e287cccc20cb5f2438a95667abc5810327c414eee7b3c79ed1b5a348a40284ea872958f50caba69432c40405eb0acce
@@ -3772,28 +3772,28 @@ __metadata:
 
 "big.js@npm:^5.2.2":
   version: 5.2.2
-  resolution: "big.js@npm:5.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbig.js%2F-%2Fbig.js-5.2.2.tgz"
+  resolution: "big.js@npm:5.2.2"
   checksum: 10c0/230520f1ff920b2d2ce3e372d77a33faa4fa60d802fe01ca4ffbc321ee06023fe9a741ac02793ee778040a16b7e497f7d60c504d1c402b8fdab6f03bb785a25f
   languageName: node
   linkType: hard
 
 "bignumber.js@npm:^9.0.0":
   version: 9.3.1
-  resolution: "bignumber.js@npm:9.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbignumber.js%2F-%2Fbignumber.js-9.3.1.tgz"
+  resolution: "bignumber.js@npm:9.3.1"
   checksum: 10c0/61342ba5fe1c10887f0ecf5be02ff6709271481aff48631f86b4d37d55a99b87ce441cfd54df3d16d10ee07ceab7e272fc0be430c657ffafbbbf7b7d631efb75
   languageName: node
   linkType: hard
 
 "binary-extensions@npm:^2.0.0":
   version: 2.3.0
-  resolution: "binary-extensions@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbinary-extensions%2F-%2Fbinary-extensions-2.3.0.tgz"
+  resolution: "binary-extensions@npm:2.3.0"
   checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
   languageName: node
   linkType: hard
 
 "body-parser@npm:^1.20.2, body-parser@npm:~1.20.3":
   version: 1.20.4
-  resolution: "body-parser@npm:1.20.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbody-parser%2F-%2Fbody-parser-1.20.4.tgz"
+  resolution: "body-parser@npm:1.20.4"
   dependencies:
     bytes: "npm:~3.1.2"
     content-type: "npm:~1.0.5"
@@ -3813,7 +3813,7 @@ __metadata:
 
 "boxen@npm:^8.0.1":
   version: 8.0.1
-  resolution: "boxen@npm:8.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fboxen%2F-%2Fboxen-8.0.1.tgz"
+  resolution: "boxen@npm:8.0.1"
   dependencies:
     ansi-align: "npm:^3.0.1"
     camelcase: "npm:^8.0.0"
@@ -3829,7 +3829,7 @@ __metadata:
 
 "brace-expansion@npm:^1.1.7":
   version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.12.tgz"
+  resolution: "brace-expansion@npm:1.1.12"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
@@ -3839,7 +3839,7 @@ __metadata:
 
 "brace-expansion@npm:^2.0.1":
   version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbrace-expansion%2F-%2Fbrace-expansion-2.0.2.tgz"
+  resolution: "brace-expansion@npm:2.0.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
@@ -3848,7 +3848,7 @@ __metadata:
 
 "braces@npm:^3.0.3, braces@npm:~3.0.2":
   version: 3.0.3
-  resolution: "braces@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbraces%2F-%2Fbraces-3.0.3.tgz"
+  resolution: "braces@npm:3.0.3"
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10c0/7c6dfd30c338d2997ba77500539227b9d1f85e388a5f43220865201e407e076783d0881f2d297b9f80951b4c957fcf0b51c1d2d24227631643c3f7c284b0aa04
@@ -3857,14 +3857,14 @@ __metadata:
 
 "browserslist-load-config@npm:^1.0.1":
   version: 1.0.1
-  resolution: "browserslist-load-config@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbrowserslist-load-config%2F-%2Fbrowserslist-load-config-1.0.1.tgz"
+  resolution: "browserslist-load-config@npm:1.0.1"
   checksum: 10c0/38dadc6f1b8b2fd4036fc3233a7395a1f5eb808c4dcda2a6109375a490b42e3cf1304bef60ecf7df40f70957ff108932a9ba2b19e867c2a56ce4dfec1275f565
   languageName: node
   linkType: hard
 
 "browserslist-to-es-version@npm:^1.2.0":
   version: 1.3.0
-  resolution: "browserslist-to-es-version@npm:1.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbrowserslist-to-es-version%2F-%2Fbrowserslist-to-es-version-1.3.0.tgz"
+  resolution: "browserslist-to-es-version@npm:1.3.0"
   dependencies:
     browserslist: "npm:^4.28.1"
   checksum: 10c0/69bb585500d1f819005a939d7b0025fdb66ce0db532792cb09213847d0ced87993c981569b0f4fdd693671a4095a24b7cbb192c1af7433811b734b3c2c47c0ec
@@ -3873,7 +3873,7 @@ __metadata:
 
 "browserslist@npm:^4.12.0, browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
   version: 4.28.1
-  resolution: "browserslist@npm:4.28.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbrowserslist%2F-%2Fbrowserslist-4.28.1.tgz"
+  resolution: "browserslist@npm:4.28.1"
   dependencies:
     baseline-browser-mapping: "npm:^2.9.0"
     caniuse-lite: "npm:^1.0.30001759"
@@ -3888,21 +3888,21 @@ __metadata:
 
 "buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
-  resolution: "buffer-equal-constant-time@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbuffer-equal-constant-time%2F-%2Fbuffer-equal-constant-time-1.0.1.tgz"
+  resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
   languageName: node
   linkType: hard
 
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
-  resolution: "buffer-from@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbuffer-from%2F-%2Fbuffer-from-1.1.2.tgz"
+  resolution: "buffer-from@npm:1.1.2"
   checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
   languageName: node
   linkType: hard
 
 "bundle-name@npm:^4.1.0":
   version: 4.1.0
-  resolution: "bundle-name@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbundle-name%2F-%2Fbundle-name-4.1.0.tgz"
+  resolution: "bundle-name@npm:4.1.0"
   dependencies:
     run-applescript: "npm:^7.0.0"
   checksum: 10c0/8e575981e79c2bcf14d8b1c027a3775c095d362d1382312f444a7c861b0e21513c0bd8db5bd2b16e50ba0709fa622d4eab6b53192d222120305e68359daece29
@@ -3911,14 +3911,14 @@ __metadata:
 
 "bytes@npm:3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
-  resolution: "bytes@npm:3.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbytes%2F-%2Fbytes-3.1.2.tgz"
+  resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
   languageName: node
   linkType: hard
 
 "cacache@npm:^20.0.1":
   version: 20.0.3
-  resolution: "cacache@npm:20.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcacache%2F-%2Fcacache-20.0.3.tgz"
+  resolution: "cacache@npm:20.0.3"
   dependencies:
     "@npmcli/fs": "npm:^5.0.0"
     fs-minipass: "npm:^3.0.0"
@@ -3937,7 +3937,7 @@ __metadata:
 
 "call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
   version: 1.0.2
-  resolution: "call-bind-apply-helpers@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcall-bind-apply-helpers%2F-%2Fcall-bind-apply-helpers-1.0.2.tgz"
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
   dependencies:
     es-errors: "npm:^1.3.0"
     function-bind: "npm:^1.1.2"
@@ -3947,7 +3947,7 @@ __metadata:
 
 "call-bound@npm:^1.0.2":
   version: 1.0.4
-  resolution: "call-bound@npm:1.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcall-bound%2F-%2Fcall-bound-1.0.4.tgz"
+  resolution: "call-bound@npm:1.0.4"
   dependencies:
     call-bind-apply-helpers: "npm:^1.0.2"
     get-intrinsic: "npm:^1.3.0"
@@ -3957,35 +3957,35 @@ __metadata:
 
 "callsites@npm:^3.0.0":
   version: 3.1.0
-  resolution: "callsites@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcallsites%2F-%2Fcallsites-3.1.0.tgz"
+  resolution: "callsites@npm:3.1.0"
   checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
   languageName: node
   linkType: hard
 
 "camelcase@npm:^8.0.0":
   version: 8.0.0
-  resolution: "camelcase@npm:8.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcamelcase%2F-%2Fcamelcase-8.0.0.tgz"
+  resolution: "camelcase@npm:8.0.0"
   checksum: 10c0/56c5fe072f0523c9908cdaac21d4a3b3fb0f608fb2e9ba90a60e792b95dd3bb3d1f3523873ab17d86d146e94171305f73ef619e2f538bd759675bc4a14b4bff3
   languageName: node
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001759":
   version: 1.0.30001764
-  resolution: "caniuse-lite@npm:1.0.30001764::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcaniuse-lite%2F-%2Fcaniuse-lite-1.0.30001764.tgz"
+  resolution: "caniuse-lite@npm:1.0.30001764"
   checksum: 10c0/3fbc2bcb35792bd860e20210283e7c700aab10c5af435dbb8bfbf952edccaa3e7de8b479af0f600c4d23f269dbc166e16b7b72df5cd1981653b252174c9cbfa8
   languageName: node
   linkType: hard
 
 "chai@npm:^6.0.1":
   version: 6.2.2
-  resolution: "chai@npm:6.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchai%2F-%2Fchai-6.2.2.tgz"
+  resolution: "chai@npm:6.2.2"
   checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
 "chalk-template@npm:^1.1.0":
   version: 1.1.2
-  resolution: "chalk-template@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchalk-template%2F-%2Fchalk-template-1.1.2.tgz"
+  resolution: "chalk-template@npm:1.1.2"
   dependencies:
     chalk: "npm:^5.2.0"
   checksum: 10c0/6d29b185c613cb117ae87c67cef80f531ae860ffb798f94dbf46597c3abaf69eb55bea5e57a99713086933c461ccff918bb70c6af491b83b109654da8b2c006f
@@ -3994,7 +3994,7 @@ __metadata:
 
 "chalk@npm:^1.0.0, chalk@npm:^1.1.3":
   version: 1.1.3
-  resolution: "chalk@npm:1.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchalk%2F-%2Fchalk-1.1.3.tgz"
+  resolution: "chalk@npm:1.1.3"
   dependencies:
     ansi-styles: "npm:^2.2.1"
     escape-string-regexp: "npm:^1.0.2"
@@ -4007,7 +4007,7 @@ __metadata:
 
 "chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
-  resolution: "chalk@npm:2.4.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchalk%2F-%2Fchalk-2.4.2.tgz"
+  resolution: "chalk@npm:2.4.2"
   dependencies:
     ansi-styles: "npm:^3.2.1"
     escape-string-regexp: "npm:^1.0.5"
@@ -4018,7 +4018,7 @@ __metadata:
 
 "chalk@npm:^4.1.0":
   version: 4.1.2
-  resolution: "chalk@npm:4.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchalk%2F-%2Fchalk-4.1.2.tgz"
+  resolution: "chalk@npm:4.1.2"
   dependencies:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
@@ -4028,14 +4028,14 @@ __metadata:
 
 "chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:^5.4.1":
   version: 5.6.2
-  resolution: "chalk@npm:5.6.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchalk%2F-%2Fchalk-5.6.2.tgz"
+  resolution: "chalk@npm:5.6.2"
   checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
   languageName: node
   linkType: hard
 
 "character-parser@npm:^2.2.0":
   version: 2.2.0
-  resolution: "character-parser@npm:2.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcharacter-parser%2F-%2Fcharacter-parser-2.2.0.tgz"
+  resolution: "character-parser@npm:2.2.0"
   dependencies:
     is-regex: "npm:^1.0.3"
   checksum: 10c0/5a8d3eff2c912a6878c84e2ebf9d42524e858aa7e1a1c7e8bb79ab54da109ad008fe9057a9d2b3230541d7ff858eda98983a2ae15db57ba01af2e989d29e932e
@@ -4044,21 +4044,21 @@ __metadata:
 
 "chardet@npm:^0.7.0":
   version: 0.7.0
-  resolution: "chardet@npm:0.7.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchardet%2F-%2Fchardet-0.7.0.tgz"
+  resolution: "chardet@npm:0.7.0"
   checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
   languageName: node
   linkType: hard
 
 "chardet@npm:^2.1.1":
   version: 2.1.1
-  resolution: "chardet@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchardet%2F-%2Fchardet-2.1.1.tgz"
+  resolution: "chardet@npm:2.1.1"
   checksum: 10c0/d8391dd412338442b3de0d3a488aa9327f8bcf74b62b8723d6bd0b85c4084d50b731320e0a7c710edb1d44de75969995d2784b80e4c13b004a6c7a0db4c6e793
   languageName: node
   linkType: hard
 
 "chokidar@npm:^3.5.1":
   version: 3.6.0
-  resolution: "chokidar@npm:3.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchokidar%2F-%2Fchokidar-3.6.0.tgz"
+  resolution: "chokidar@npm:3.6.0"
   dependencies:
     anymatch: "npm:~3.1.2"
     braces: "npm:~3.0.2"
@@ -4077,7 +4077,7 @@ __metadata:
 
 "chokidar@npm:^4.0.0":
   version: 4.0.3
-  resolution: "chokidar@npm:4.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchokidar%2F-%2Fchokidar-4.0.3.tgz"
+  resolution: "chokidar@npm:4.0.3"
   dependencies:
     readdirp: "npm:^4.0.1"
   checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
@@ -4086,21 +4086,21 @@ __metadata:
 
 "chownr@npm:^3.0.0":
   version: 3.0.0
-  resolution: "chownr@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fchownr%2F-%2Fchownr-3.0.0.tgz"
+  resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
   languageName: node
   linkType: hard
 
 "cli-boxes@npm:^3.0.0":
   version: 3.0.0
-  resolution: "cli-boxes@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-boxes%2F-%2Fcli-boxes-3.0.0.tgz"
+  resolution: "cli-boxes@npm:3.0.0"
   checksum: 10c0/4db3e8fbfaf1aac4fb3a6cbe5a2d3fa048bee741a45371b906439b9ffc821c6e626b0f108bdcd3ddf126a4a319409aedcf39a0730573ff050fdd7b6731e99fb9
   languageName: node
   linkType: hard
 
 "cli-cursor@npm:^2.0.0, cli-cursor@npm:^2.1.0":
   version: 2.1.0
-  resolution: "cli-cursor@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-cursor%2F-%2Fcli-cursor-2.1.0.tgz"
+  resolution: "cli-cursor@npm:2.1.0"
   dependencies:
     restore-cursor: "npm:^2.0.0"
   checksum: 10c0/09ee6d8b5b818d840bf80ec9561eaf696672197d3a02a7daee2def96d5f52ce6e0bbe7afca754ccf14f04830b5a1b4556273e983507d5029f95bba3016618eda
@@ -4109,7 +4109,7 @@ __metadata:
 
 "cli-cursor@npm:^3.1.0":
   version: 3.1.0
-  resolution: "cli-cursor@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-cursor%2F-%2Fcli-cursor-3.1.0.tgz"
+  resolution: "cli-cursor@npm:3.1.0"
   dependencies:
     restore-cursor: "npm:^3.1.0"
   checksum: 10c0/92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
@@ -4118,7 +4118,7 @@ __metadata:
 
 "cli-truncate@npm:^0.2.1":
   version: 0.2.1
-  resolution: "cli-truncate@npm:0.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-truncate%2F-%2Fcli-truncate-0.2.1.tgz"
+  resolution: "cli-truncate@npm:0.2.1"
   dependencies:
     slice-ansi: "npm:0.0.4"
     string-width: "npm:^1.0.1"
@@ -4128,28 +4128,28 @@ __metadata:
 
 "cli-width@npm:^2.0.0":
   version: 2.2.1
-  resolution: "cli-width@npm:2.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-width%2F-%2Fcli-width-2.2.1.tgz"
+  resolution: "cli-width@npm:2.2.1"
   checksum: 10c0/e3a6d422d657ca111c630f69ee0f1a499e8f114eea158ccb2cdbedd19711edffa217093bbd43dafb34b68d1b1a3b5334126e51d059b9ec1d19afa53b42b3ef86
   languageName: node
   linkType: hard
 
 "cli-width@npm:^3.0.0":
   version: 3.0.0
-  resolution: "cli-width@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-width%2F-%2Fcli-width-3.0.0.tgz"
+  resolution: "cli-width@npm:3.0.0"
   checksum: 10c0/125a62810e59a2564268c80fdff56c23159a7690c003e34aeb2e68497dccff26911998ff49c33916fcfdf71e824322cc3953e3f7b48b27267c7a062c81348a9a
   languageName: node
   linkType: hard
 
 "cli-width@npm:^4.1.0":
   version: 4.1.0
-  resolution: "cli-width@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcli-width%2F-%2Fcli-width-4.1.0.tgz"
+  resolution: "cli-width@npm:4.1.0"
   checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
   languageName: node
   linkType: hard
 
 "cliui@npm:^8.0.1":
   version: 8.0.1
-  resolution: "cliui@npm:8.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcliui%2F-%2Fcliui-8.0.1.tgz"
+  resolution: "cliui@npm:8.0.1"
   dependencies:
     string-width: "npm:^4.2.0"
     strip-ansi: "npm:^6.0.1"
@@ -4160,7 +4160,7 @@ __metadata:
 
 "cliui@npm:^9.0.1":
   version: 9.0.1
-  resolution: "cliui@npm:9.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcliui%2F-%2Fcliui-9.0.1.tgz"
+  resolution: "cliui@npm:9.0.1"
   dependencies:
     string-width: "npm:^7.2.0"
     strip-ansi: "npm:^7.1.0"
@@ -4171,21 +4171,21 @@ __metadata:
 
 "cluster-key-slot@npm:^1.1.0":
   version: 1.1.2
-  resolution: "cluster-key-slot@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcluster-key-slot%2F-%2Fcluster-key-slot-1.1.2.tgz"
+  resolution: "cluster-key-slot@npm:1.1.2"
   checksum: 10c0/d7d39ca28a8786e9e801eeb8c770e3c3236a566625d7299a47bb71113fb2298ce1039596acb82590e598c52dbc9b1f088c8f587803e697cb58e1867a95ff94d3
   languageName: node
   linkType: hard
 
 "code-point-at@npm:^1.0.0":
   version: 1.1.0
-  resolution: "code-point-at@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcode-point-at%2F-%2Fcode-point-at-1.1.0.tgz"
+  resolution: "code-point-at@npm:1.1.0"
   checksum: 10c0/33f6b234084e46e6e369b6f0b07949392651b4dde70fc6a592a8d3dafa08d5bb32e3981a02f31f6fc323a26bc03a4c063a9d56834848695bda7611c2417ea2e6
   languageName: node
   linkType: hard
 
 "code-red@npm:^1.0.3":
   version: 1.0.4
-  resolution: "code-red@npm:1.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcode-red%2F-%2Fcode-red-1.0.4.tgz"
+  resolution: "code-red@npm:1.0.4"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.4.15"
     "@types/estree": "npm:^1.0.1"
@@ -4198,7 +4198,7 @@ __metadata:
 
 "color-convert@npm:^1.9.0":
   version: 1.9.3
-  resolution: "color-convert@npm:1.9.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcolor-convert%2F-%2Fcolor-convert-1.9.3.tgz"
+  resolution: "color-convert@npm:1.9.3"
   dependencies:
     color-name: "npm:1.1.3"
   checksum: 10c0/5ad3c534949a8c68fca8fbc6f09068f435f0ad290ab8b2f76841b9e6af7e0bb57b98cb05b0e19fe33f5d91e5a8611ad457e5f69e0a484caad1f7487fd0e8253c
@@ -4207,7 +4207,7 @@ __metadata:
 
 "color-convert@npm:^2.0.1":
   version: 2.0.1
-  resolution: "color-convert@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcolor-convert%2F-%2Fcolor-convert-2.0.1.tgz"
+  resolution: "color-convert@npm:2.0.1"
   dependencies:
     color-name: "npm:~1.1.4"
   checksum: 10c0/37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
@@ -4216,21 +4216,21 @@ __metadata:
 
 "color-name@npm:1.1.3":
   version: 1.1.3
-  resolution: "color-name@npm:1.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcolor-name%2F-%2Fcolor-name-1.1.3.tgz"
+  resolution: "color-name@npm:1.1.3"
   checksum: 10c0/566a3d42cca25b9b3cd5528cd7754b8e89c0eb646b7f214e8e2eaddb69994ac5f0557d9c175eb5d8f0ad73531140d9c47525085ee752a91a2ab15ab459caf6d6
   languageName: node
   linkType: hard
 
 "color-name@npm:~1.1.4":
   version: 1.1.4
-  resolution: "color-name@npm:1.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcolor-name%2F-%2Fcolor-name-1.1.4.tgz"
+  resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
   languageName: node
   linkType: hard
 
 "color-support@npm:^1.1.3":
   version: 1.1.3
-  resolution: "color-support@npm:1.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcolor-support%2F-%2Fcolor-support-1.1.3.tgz"
+  resolution: "color-support@npm:1.1.3"
   bin:
     color-support: bin.js
   checksum: 10c0/8ffeaa270a784dc382f62d9be0a98581db43e11eee301af14734a6d089bd456478b1a8b3e7db7ca7dc5b18a75f828f775c44074020b51c05fc00e6d0992b1cc6
@@ -4239,7 +4239,7 @@ __metadata:
 
 "combined-stream@npm:^1.0.8":
   version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcombined-stream%2F-%2Fcombined-stream-1.0.8.tgz"
+  resolution: "combined-stream@npm:1.0.8"
   dependencies:
     delayed-stream: "npm:~1.0.0"
   checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
@@ -4248,14 +4248,14 @@ __metadata:
 
 "commander@npm:^2.20.0":
   version: 2.20.3
-  resolution: "commander@npm:2.20.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcommander%2F-%2Fcommander-2.20.3.tgz"
+  resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
   languageName: node
   linkType: hard
 
 "compressible@npm:~2.0.18":
   version: 2.0.18
-  resolution: "compressible@npm:2.0.18::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcompressible%2F-%2Fcompressible-2.0.18.tgz"
+  resolution: "compressible@npm:2.0.18"
   dependencies:
     mime-db: "npm:>= 1.43.0 < 2"
   checksum: 10c0/8a03712bc9f5b9fe530cc5a79e164e665550d5171a64575d7dcf3e0395d7b4afa2d79ab176c61b5b596e28228b350dd07c1a2a6ead12fd81d1b6cd632af2fef7
@@ -4264,7 +4264,7 @@ __metadata:
 
 "compression@npm:^1.7.4":
   version: 1.8.1
-  resolution: "compression@npm:1.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcompression%2F-%2Fcompression-1.8.1.tgz"
+  resolution: "compression@npm:1.8.1"
   dependencies:
     bytes: "npm:3.1.2"
     compressible: "npm:~2.0.18"
@@ -4279,21 +4279,21 @@ __metadata:
 
 "concat-map@npm:0.0.1":
   version: 0.0.1
-  resolution: "concat-map@npm:0.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconcat-map%2F-%2Fconcat-map-0.0.1.tgz"
+  resolution: "concat-map@npm:0.0.1"
   checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
   languageName: node
   linkType: hard
 
 "confbox@npm:^0.1.8":
   version: 0.1.8
-  resolution: "confbox@npm:0.1.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconfbox%2F-%2Fconfbox-0.1.8.tgz"
+  resolution: "confbox@npm:0.1.8"
   checksum: 10c0/fc2c68d97cb54d885b10b63e45bd8da83a8a71459d3ecf1825143dd4c7f9f1b696b3283e07d9d12a144c1301c2ebc7842380bdf0014e55acc4ae1c9550102418
   languageName: node
   linkType: hard
 
 "config-chain@npm:^1.1.11":
   version: 1.1.13
-  resolution: "config-chain@npm:1.1.13::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconfig-chain%2F-%2Fconfig-chain-1.1.13.tgz"
+  resolution: "config-chain@npm:1.1.13"
   dependencies:
     ini: "npm:^1.3.4"
     proto-list: "npm:~1.2.1"
@@ -4303,7 +4303,7 @@ __metadata:
 
 "configstore@npm:^7.0.0":
   version: 7.1.0
-  resolution: "configstore@npm:7.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconfigstore%2F-%2Fconfigstore-7.1.0.tgz"
+  resolution: "configstore@npm:7.1.0"
   dependencies:
     atomically: "npm:^2.0.3"
     dot-prop: "npm:^9.0.0"
@@ -4315,7 +4315,7 @@ __metadata:
 
 "connect-redis@npm:^7.1.1":
   version: 7.1.1
-  resolution: "connect-redis@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconnect-redis%2F-%2Fconnect-redis-7.1.1.tgz"
+  resolution: "connect-redis@npm:7.1.1"
   peerDependencies:
     express-session: ">=1"
   checksum: 10c0/eeb9e275176d1ef973c808df7c860c80300dfdecdee1a8ca20524fc4e37ccb2206923b07f17501fb7235cde73e9db9e06dff79ef17a54e5a57f35db247ec99fb
@@ -4324,14 +4324,14 @@ __metadata:
 
 "console-control-strings@npm:^1.1.0":
   version: 1.1.0
-  resolution: "console-control-strings@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconsole-control-strings%2F-%2Fconsole-control-strings-1.1.0.tgz"
+  resolution: "console-control-strings@npm:1.1.0"
   checksum: 10c0/7ab51d30b52d461412cd467721bb82afe695da78fff8f29fe6f6b9cbaac9a2328e27a22a966014df9532100f6dd85370460be8130b9c677891ba36d96a343f50
   languageName: node
   linkType: hard
 
 "constantinople@npm:^4.0.1":
   version: 4.0.1
-  resolution: "constantinople@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconstantinople%2F-%2Fconstantinople-4.0.1.tgz"
+  resolution: "constantinople@npm:4.0.1"
   dependencies:
     "@babel/parser": "npm:^7.6.0"
     "@babel/types": "npm:^7.6.1"
@@ -4341,7 +4341,7 @@ __metadata:
 
 "content-disposition@npm:~0.5.4":
   version: 0.5.4
-  resolution: "content-disposition@npm:0.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcontent-disposition%2F-%2Fcontent-disposition-0.5.4.tgz"
+  resolution: "content-disposition@npm:0.5.4"
   dependencies:
     safe-buffer: "npm:5.2.1"
   checksum: 10c0/bac0316ebfeacb8f381b38285dc691c9939bf0a78b0b7c2d5758acadad242d04783cee5337ba7d12a565a19075af1b3c11c728e1e4946de73c6ff7ce45f3f1bb
@@ -4350,21 +4350,21 @@ __metadata:
 
 "content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
-  resolution: "content-type@npm:1.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcontent-type%2F-%2Fcontent-type-1.0.5.tgz"
+  resolution: "content-type@npm:1.0.5"
   checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
   languageName: node
   linkType: hard
 
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
-  resolution: "convert-source-map@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fconvert-source-map%2F-%2Fconvert-source-map-2.0.0.tgz"
+  resolution: "convert-source-map@npm:2.0.0"
   checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
   languageName: node
   linkType: hard
 
 "cookie-parser@npm:^1.4.6":
   version: 1.4.7
-  resolution: "cookie-parser@npm:1.4.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcookie-parser%2F-%2Fcookie-parser-1.4.7.tgz"
+  resolution: "cookie-parser@npm:1.4.7"
   dependencies:
     cookie: "npm:0.7.2"
     cookie-signature: "npm:1.0.6"
@@ -4374,35 +4374,35 @@ __metadata:
 
 "cookie-signature@npm:1.0.6":
   version: 1.0.6
-  resolution: "cookie-signature@npm:1.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcookie-signature%2F-%2Fcookie-signature-1.0.6.tgz"
+  resolution: "cookie-signature@npm:1.0.6"
   checksum: 10c0/b36fd0d4e3fef8456915fcf7742e58fbfcc12a17a018e0eb9501c9d5ef6893b596466f03b0564b81af29ff2538fd0aa4b9d54fe5ccbfb4c90ea50ad29fe2d221
   languageName: node
   linkType: hard
 
 "cookie-signature@npm:~1.0.6, cookie-signature@npm:~1.0.7":
   version: 1.0.7
-  resolution: "cookie-signature@npm:1.0.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcookie-signature%2F-%2Fcookie-signature-1.0.7.tgz"
+  resolution: "cookie-signature@npm:1.0.7"
   checksum: 10c0/e7731ad2995ae2efeed6435ec1e22cdd21afef29d300c27281438b1eab2bae04ef0d1a203928c0afec2cee72aa36540b8747406ebe308ad23c8e8cc3c26c9c51
   languageName: node
   linkType: hard
 
 "cookie@npm:0.4.0":
   version: 0.4.0
-  resolution: "cookie@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcookie%2F-%2Fcookie-0.4.0.tgz"
+  resolution: "cookie@npm:0.4.0"
   checksum: 10c0/71508a1c8a4e97bb88f42635542ef24ebe7e713f82573ac61e9b289616334d14bfb28210d7979d9ada24b0254f5fb563af938cac13bc8c0c3f60f47a2257f791
   languageName: node
   linkType: hard
 
 "cookie@npm:0.7.2, cookie@npm:~0.7.1, cookie@npm:~0.7.2":
   version: 0.7.2
-  resolution: "cookie@npm:0.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcookie%2F-%2Fcookie-0.7.2.tgz"
+  resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
   languageName: node
   linkType: hard
 
 "copy-anything@npm:^2.0.1":
   version: 2.0.6
-  resolution: "copy-anything@npm:2.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcopy-anything%2F-%2Fcopy-anything-2.0.6.tgz"
+  resolution: "copy-anything@npm:2.0.6"
   dependencies:
     is-what: "npm:^3.14.1"
   checksum: 10c0/2702998a8cc015f9917385b7f16b0d85f1f6e5e2fd34d99f14df584838f492f49aa0c390d973684c687e895c5c58d08b308a0400ac3e1e3d6fa1e5884a5402ad
@@ -4411,7 +4411,7 @@ __metadata:
 
 "cors@npm:~2.8.5":
   version: 2.8.5
-  resolution: "cors@npm:2.8.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcors%2F-%2Fcors-2.8.5.tgz"
+  resolution: "cors@npm:2.8.5"
   dependencies:
     object-assign: "npm:^4"
     vary: "npm:^1"
@@ -4421,7 +4421,7 @@ __metadata:
 
 "cosmiconfig@npm:^8.3.6":
   version: 8.3.6
-  resolution: "cosmiconfig@npm:8.3.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcosmiconfig%2F-%2Fcosmiconfig-8.3.6.tgz"
+  resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
     import-fresh: "npm:^3.3.0"
     js-yaml: "npm:^4.1.0"
@@ -4438,7 +4438,7 @@ __metadata:
 
 "cosmiconfig@npm:^9.0.0":
   version: 9.0.0
-  resolution: "cosmiconfig@npm:9.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcosmiconfig%2F-%2Fcosmiconfig-9.0.0.tgz"
+  resolution: "cosmiconfig@npm:9.0.0"
   dependencies:
     env-paths: "npm:^2.2.1"
     import-fresh: "npm:^3.3.0"
@@ -4455,14 +4455,14 @@ __metadata:
 
 "create-require@npm:^1.1.0":
   version: 1.1.1
-  resolution: "create-require@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcreate-require%2F-%2Fcreate-require-1.1.1.tgz"
+  resolution: "create-require@npm:1.1.1"
   checksum: 10c0/157cbc59b2430ae9a90034a5f3a1b398b6738bf510f713edc4d4e45e169bc514d3d99dd34d8d01ca7ae7830b5b8b537e46ae8f3c8f932371b0875c0151d7ec91
   languageName: node
   linkType: hard
 
 "cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5":
   version: 7.0.6
-  resolution: "cross-spawn@npm:7.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcross-spawn%2F-%2Fcross-spawn-7.0.6.tgz"
+  resolution: "cross-spawn@npm:7.0.6"
   dependencies:
     path-key: "npm:^3.1.0"
     shebang-command: "npm:^2.0.0"
@@ -4473,7 +4473,7 @@ __metadata:
 
 "csrf@npm:3.1.0":
   version: 3.1.0
-  resolution: "csrf@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcsrf%2F-%2Fcsrf-3.1.0.tgz"
+  resolution: "csrf@npm:3.1.0"
   dependencies:
     rndm: "npm:1.2.0"
     tsscmp: "npm:1.0.6"
@@ -4484,7 +4484,7 @@ __metadata:
 
 "css-loader@npm:^7.1.0":
   version: 7.1.2
-  resolution: "css-loader@npm:7.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcss-loader%2F-%2Fcss-loader-7.1.2.tgz"
+  resolution: "css-loader@npm:7.1.2"
   dependencies:
     icss-utils: "npm:^5.1.0"
     postcss: "npm:^8.4.33"
@@ -4508,7 +4508,7 @@ __metadata:
 
 "css-tree@npm:^2.3.1":
   version: 2.3.1
-  resolution: "css-tree@npm:2.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcss-tree%2F-%2Fcss-tree-2.3.1.tgz"
+  resolution: "css-tree@npm:2.3.1"
   dependencies:
     mdn-data: "npm:2.0.30"
     source-map-js: "npm:^1.0.1"
@@ -4518,7 +4518,7 @@ __metadata:
 
 "cssesc@npm:^3.0.0":
   version: 3.0.0
-  resolution: "cssesc@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcssesc%2F-%2Fcssesc-3.0.0.tgz"
+  resolution: "cssesc@npm:3.0.0"
   bin:
     cssesc: bin/cssesc
   checksum: 10c0/6bcfd898662671be15ae7827120472c5667afb3d7429f1f917737f3bf84c4176003228131b643ae74543f17a394446247df090c597bb9a728cce298606ed0aa7
@@ -4527,7 +4527,7 @@ __metadata:
 
 "csurf@npm:^1.11.0":
   version: 1.11.0
-  resolution: "csurf@npm:1.11.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcsurf%2F-%2Fcsurf-1.11.0.tgz"
+  resolution: "csurf@npm:1.11.0"
   dependencies:
     cookie: "npm:0.4.0"
     cookie-signature: "npm:1.0.6"
@@ -4539,14 +4539,14 @@ __metadata:
 
 "date-fns@npm:^1.27.2":
   version: 1.30.1
-  resolution: "date-fns@npm:1.30.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdate-fns%2F-%2Fdate-fns-1.30.1.tgz"
+  resolution: "date-fns@npm:1.30.1"
   checksum: 10c0/bad6ad7c15180121e15d61ad62a4a214c108d66f35b35f5eeb6ade837a3c29aa4444b9528a93a5374b95ba11231c142276351bf52f4d168676f9a1e17ce3726a
   languageName: node
   linkType: hard
 
 "debug@npm:2.6.9, debug@npm:~2.6.9":
   version: 2.6.9
-  resolution: "debug@npm:2.6.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdebug%2F-%2Fdebug-2.6.9.tgz"
+  resolution: "debug@npm:2.6.9"
   dependencies:
     ms: "npm:2.0.0"
   checksum: 10c0/121908fb839f7801180b69a7e218a40b5a0b718813b886b7d6bdb82001b931c938e2941d1e4450f33a1b1df1da653f5f7a0440c197f29fbf8a6e9d45ff6ef589
@@ -4555,7 +4555,7 @@ __metadata:
 
 "debug@npm:3.1.0":
   version: 3.1.0
-  resolution: "debug@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdebug%2F-%2Fdebug-3.1.0.tgz"
+  resolution: "debug@npm:3.1.0"
   dependencies:
     ms: "npm:2.0.0"
   checksum: 10c0/5bff34a352d7b2eaa31886eeaf2ee534b5461ec0548315b2f9f80bd1d2533cab7df1fa52e130ce27bc31c3945fbffb0fc72baacdceb274b95ce853db89254ea4
@@ -4564,7 +4564,7 @@ __metadata:
 
 "debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.3, debug@npm:~4.4.1":
   version: 4.4.3
-  resolution: "debug@npm:4.4.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdebug%2F-%2Fdebug-4.4.3.tgz"
+  resolution: "debug@npm:4.4.3"
   dependencies:
     ms: "npm:^2.1.3"
   peerDependenciesMeta:
@@ -4576,7 +4576,7 @@ __metadata:
 
 "debug@npm:~4.3.2":
   version: 4.3.7
-  resolution: "debug@npm:4.3.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdebug%2F-%2Fdebug-4.3.7.tgz"
+  resolution: "debug@npm:4.3.7"
   dependencies:
     ms: "npm:^2.1.3"
   peerDependenciesMeta:
@@ -4588,7 +4588,7 @@ __metadata:
 
 "deep-eql@npm:4.1.4":
   version: 4.1.4
-  resolution: "deep-eql@npm:4.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdeep-eql%2F-%2Fdeep-eql-4.1.4.tgz"
+  resolution: "deep-eql@npm:4.1.4"
   dependencies:
     type-detect: "npm:^4.0.0"
   checksum: 10c0/264e0613493b43552fc908f4ff87b8b445c0e6e075656649600e1b8a17a57ee03e960156fce7177646e4d2ddaf8e5ee616d76bd79929ff593e5c79e4e5e6c517
@@ -4597,21 +4597,21 @@ __metadata:
 
 "deep-extend@npm:^0.6.0":
   version: 0.6.0
-  resolution: "deep-extend@npm:0.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdeep-extend%2F-%2Fdeep-extend-0.6.0.tgz"
+  resolution: "deep-extend@npm:0.6.0"
   checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
   languageName: node
   linkType: hard
 
 "default-browser-id@npm:^5.0.0":
   version: 5.0.1
-  resolution: "default-browser-id@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdefault-browser-id%2F-%2Fdefault-browser-id-5.0.1.tgz"
+  resolution: "default-browser-id@npm:5.0.1"
   checksum: 10c0/5288b3094c740ef3a86df9b999b04ff5ba4dee6b64e7b355c0fff5217752c8c86908d67f32f6cba9bb4f9b7b61a1b640c0a4f9e34c57e0ff3493559a625245ee
   languageName: node
   linkType: hard
 
 "default-browser@npm:^5.2.1":
   version: 5.4.0
-  resolution: "default-browser@npm:5.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdefault-browser%2F-%2Fdefault-browser-5.4.0.tgz"
+  resolution: "default-browser@npm:5.4.0"
   dependencies:
     bundle-name: "npm:^4.1.0"
     default-browser-id: "npm:^5.0.0"
@@ -4621,14 +4621,14 @@ __metadata:
 
 "define-lazy-prop@npm:^3.0.0":
   version: 3.0.0
-  resolution: "define-lazy-prop@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdefine-lazy-prop%2F-%2Fdefine-lazy-prop-3.0.0.tgz"
+  resolution: "define-lazy-prop@npm:3.0.0"
   checksum: 10c0/5ab0b2bf3fa58b3a443140bbd4cd3db1f91b985cc8a246d330b9ac3fc0b6a325a6d82bddc0b055123d745b3f9931afeea74a5ec545439a1630b9c8512b0eeb49
   languageName: node
   linkType: hard
 
 "del@npm:^8.0.0":
   version: 8.0.1
-  resolution: "del@npm:8.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdel%2F-%2Fdel-8.0.1.tgz"
+  resolution: "del@npm:8.0.1"
   dependencies:
     globby: "npm:^14.0.2"
     is-glob: "npm:^4.0.3"
@@ -4643,56 +4643,56 @@ __metadata:
 
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdelayed-stream%2F-%2Fdelayed-stream-1.0.0.tgz"
+  resolution: "delayed-stream@npm:1.0.0"
   checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
   languageName: node
   linkType: hard
 
 "denque@npm:^2.1.0":
   version: 2.1.0
-  resolution: "denque@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdenque%2F-%2Fdenque-2.1.0.tgz"
+  resolution: "denque@npm:2.1.0"
   checksum: 10c0/f9ef81aa0af9c6c614a727cb3bd13c5d7db2af1abf9e6352045b86e85873e629690f6222f4edd49d10e4ccf8f078bbeec0794fafaf61b659c0589d0c511ec363
   languageName: node
   linkType: hard
 
 "depd@npm:2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
-  resolution: "depd@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdepd%2F-%2Fdepd-2.0.0.tgz"
+  resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
   languageName: node
   linkType: hard
 
 "depd@npm:~1.1.2":
   version: 1.1.2
-  resolution: "depd@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdepd%2F-%2Fdepd-1.1.2.tgz"
+  resolution: "depd@npm:1.1.2"
   checksum: 10c0/acb24aaf936ef9a227b6be6d495f0d2eb20108a9a6ad40585c5bda1a897031512fef6484e4fdbb80bd249fdaa82841fa1039f416ece03188e677ba11bcfda249
   languageName: node
   linkType: hard
 
 "destroy@npm:1.2.0, destroy@npm:~1.2.0":
   version: 1.2.0
-  resolution: "destroy@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdestroy%2F-%2Fdestroy-1.2.0.tgz"
+  resolution: "destroy@npm:1.2.0"
   checksum: 10c0/bd7633942f57418f5a3b80d5cb53898127bcf53e24cdf5d5f4396be471417671f0fee48a4ebe9a1e9defbde2a31280011af58a57e090ff822f589b443ed4e643
   languageName: node
   linkType: hard
 
 "detect-indent@npm:^6.0.0":
   version: 6.1.0
-  resolution: "detect-indent@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdetect-indent%2F-%2Fdetect-indent-6.1.0.tgz"
+  resolution: "detect-indent@npm:6.1.0"
   checksum: 10c0/dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
   languageName: node
   linkType: hard
 
 "detect-libc@npm:^2.0.3":
   version: 2.1.2
-  resolution: "detect-libc@npm:2.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdetect-libc%2F-%2Fdetect-libc-2.1.2.tgz"
+  resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
   languageName: node
   linkType: hard
 
 "dezalgo@npm:^1.0.4":
   version: 1.0.4
-  resolution: "dezalgo@npm:1.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdezalgo%2F-%2Fdezalgo-1.0.4.tgz"
+  resolution: "dezalgo@npm:1.0.4"
   dependencies:
     asap: "npm:^2.0.0"
     wrappy: "npm:1"
@@ -4702,14 +4702,14 @@ __metadata:
 
 "diff@npm:^4.0.1":
   version: 4.0.2
-  resolution: "diff@npm:4.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdiff%2F-%2Fdiff-4.0.2.tgz"
+  resolution: "diff@npm:4.0.2"
   checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
   languageName: node
   linkType: hard
 
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
-  resolution: "dir-glob@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdir-glob%2F-%2Fdir-glob-3.0.1.tgz"
+  resolution: "dir-glob@npm:3.0.1"
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
@@ -4718,14 +4718,14 @@ __metadata:
 
 "doctypes@npm:^1.1.0":
   version: 1.1.0
-  resolution: "doctypes@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdoctypes%2F-%2Fdoctypes-1.1.0.tgz"
+  resolution: "doctypes@npm:1.1.0"
   checksum: 10c0/b3f9d597ad8b9ac6aeba9d64df61f0098174f7570e3d34f7ee245ebc736c7bee122d9738a18e22010b98983fd9a340d63043d3841f02d8a7742a2d96d2c72610
   languageName: node
   linkType: hard
 
 "dom-serializer@npm:^2.0.0":
   version: 2.0.0
-  resolution: "dom-serializer@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdom-serializer%2F-%2Fdom-serializer-2.0.0.tgz"
+  resolution: "dom-serializer@npm:2.0.0"
   dependencies:
     domelementtype: "npm:^2.3.0"
     domhandler: "npm:^5.0.2"
@@ -4736,14 +4736,14 @@ __metadata:
 
 "domelementtype@npm:^2.3.0":
   version: 2.3.0
-  resolution: "domelementtype@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdomelementtype%2F-%2Fdomelementtype-2.3.0.tgz"
+  resolution: "domelementtype@npm:2.3.0"
   checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
   languageName: node
   linkType: hard
 
 "domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
   version: 5.0.3
-  resolution: "domhandler@npm:5.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdomhandler%2F-%2Fdomhandler-5.0.3.tgz"
+  resolution: "domhandler@npm:5.0.3"
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
@@ -4752,7 +4752,7 @@ __metadata:
 
 "domutils@npm:^3.2.1":
   version: 3.2.2
-  resolution: "domutils@npm:3.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdomutils%2F-%2Fdomutils-3.2.2.tgz"
+  resolution: "domutils@npm:3.2.2"
   dependencies:
     dom-serializer: "npm:^2.0.0"
     domelementtype: "npm:^2.3.0"
@@ -4763,7 +4763,7 @@ __metadata:
 
 "dot-prop@npm:^9.0.0":
   version: 9.0.0
-  resolution: "dot-prop@npm:9.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdot-prop%2F-%2Fdot-prop-9.0.0.tgz"
+  resolution: "dot-prop@npm:9.0.0"
   dependencies:
     type-fest: "npm:^4.18.2"
   checksum: 10c0/4bac49a2f559156811862ac92813906f70529c50da918eaab81b38dd869743c667d578e183607f5ae11e8ae2a02e43e98e32c8a37bc4cae76b04d5b576e3112f
@@ -4772,21 +4772,21 @@ __metadata:
 
 "dotenv@npm:^16.4.5":
   version: 16.6.1
-  resolution: "dotenv@npm:16.6.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdotenv%2F-%2Fdotenv-16.6.1.tgz"
+  resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
   languageName: node
   linkType: hard
 
 "dotenv@npm:^17.2.3":
   version: 17.2.3
-  resolution: "dotenv@npm:17.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdotenv%2F-%2Fdotenv-17.2.3.tgz"
+  resolution: "dotenv@npm:17.2.3"
   checksum: 10c0/c884403209f713214a1b64d4d1defa4934c2aa5b0002f5a670ae298a51e3c3ad3ba79dfee2f8df49f01ae74290fcd9acdb1ab1d09c7bfb42b539036108bb2ba0
   languageName: node
   linkType: hard
 
 "dunder-proto@npm:^1.0.1":
   version: 1.0.1
-  resolution: "dunder-proto@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdunder-proto%2F-%2Fdunder-proto-1.0.1.tgz"
+  resolution: "dunder-proto@npm:1.0.1"
   dependencies:
     call-bind-apply-helpers: "npm:^1.0.1"
     es-errors: "npm:^1.3.0"
@@ -4797,7 +4797,7 @@ __metadata:
 
 "duplexify@npm:^4.0.0, duplexify@npm:^4.1.3":
   version: 4.1.3
-  resolution: "duplexify@npm:4.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fduplexify%2F-%2Fduplexify-4.1.3.tgz"
+  resolution: "duplexify@npm:4.1.3"
   dependencies:
     end-of-stream: "npm:^1.4.1"
     inherits: "npm:^2.0.3"
@@ -4809,7 +4809,7 @@ __metadata:
 
 "dynamic-dedupe@npm:^0.3.0":
   version: 0.3.0
-  resolution: "dynamic-dedupe@npm:0.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdynamic-dedupe%2F-%2Fdynamic-dedupe-0.3.0.tgz"
+  resolution: "dynamic-dedupe@npm:0.3.0"
   dependencies:
     xtend: "npm:^4.0.0"
   checksum: 10c0/505a79f05221daaa5b6d4b6dddc30881809a136810acea138bf56e784b15c237077864ae18824b5dfb0f836a321d14cec0b7cec004e6abf31c38a1e9862af22b
@@ -4818,7 +4818,7 @@ __metadata:
 
 "ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
   version: 1.0.11
-  resolution: "ecdsa-sig-formatter@npm:1.0.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fecdsa-sig-formatter%2F-%2Fecdsa-sig-formatter-1.0.11.tgz"
+  resolution: "ecdsa-sig-formatter@npm:1.0.11"
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
@@ -4827,56 +4827,56 @@ __metadata:
 
 "ee-first@npm:1.1.1":
   version: 1.1.1
-  resolution: "ee-first@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fee-first%2F-%2Fee-first-1.1.1.tgz"
+  resolution: "ee-first@npm:1.1.1"
   checksum: 10c0/b5bb125ee93161bc16bfe6e56c6b04de5ad2aa44234d8f644813cc95d861a6910903132b05093706de2b706599367c4130eb6d170f6b46895686b95f87d017b7
   languageName: node
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.263":
   version: 1.5.267
-  resolution: "electron-to-chromium@npm:1.5.267::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Felectron-to-chromium%2F-%2Felectron-to-chromium-1.5.267.tgz"
+  resolution: "electron-to-chromium@npm:1.5.267"
   checksum: 10c0/0732bdb891b657f2e43266a3db8cf86fff6cecdcc8d693a92beff214e136cb5c2ee7dc5945ed75fa1db16e16bad0c38695527a020d15f39e79084e0b2e447621
   languageName: node
   linkType: hard
 
 "elegant-spinner@npm:^1.0.1":
   version: 1.0.1
-  resolution: "elegant-spinner@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Felegant-spinner%2F-%2Felegant-spinner-1.0.1.tgz"
+  resolution: "elegant-spinner@npm:1.0.1"
   checksum: 10c0/df607c83c20fc3ce56c514175dd5d1ee7f667da00cee13d04d32c70d55e76555091fa236689e691cf7dedba17b0020fec635e499cdde84dbea2ef8639314e5f8
   languageName: node
   linkType: hard
 
 "emoji-regex@npm:^10.3.0":
   version: 10.6.0
-  resolution: "emoji-regex@npm:10.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Femoji-regex%2F-%2Femoji-regex-10.6.0.tgz"
+  resolution: "emoji-regex@npm:10.6.0"
   checksum: 10c0/1e4aa097bb007301c3b4b1913879ae27327fdc48e93eeefefe3b87e495eb33c5af155300be951b4349ff6ac084f4403dc9eff970acba7c1c572d89396a9a32d7
   languageName: node
   linkType: hard
 
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
-  resolution: "emoji-regex@npm:8.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Femoji-regex%2F-%2Femoji-regex-8.0.0.tgz"
+  resolution: "emoji-regex@npm:8.0.0"
   checksum: 10c0/b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
   languageName: node
   linkType: hard
 
 "emojis-list@npm:^3.0.0":
   version: 3.0.0
-  resolution: "emojis-list@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Femojis-list%2F-%2Femojis-list-3.0.0.tgz"
+  resolution: "emojis-list@npm:3.0.0"
   checksum: 10c0/7dc4394b7b910444910ad64b812392159a21e1a7ecc637c775a440227dcb4f80eff7fe61f4453a7d7603fa23d23d30cc93fe9e4b5ed985b88d6441cd4a35117b
   languageName: node
   linkType: hard
 
 "encodeurl@npm:~2.0.0":
   version: 2.0.0
-  resolution: "encodeurl@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fencodeurl%2F-%2Fencodeurl-2.0.0.tgz"
+  resolution: "encodeurl@npm:2.0.0"
   checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
   languageName: node
   linkType: hard
 
 "encoding@npm:^0.1.13":
   version: 0.1.13
-  resolution: "encoding@npm:0.1.13::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fencoding%2F-%2Fencoding-0.1.13.tgz"
+  resolution: "encoding@npm:0.1.13"
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
@@ -4885,7 +4885,7 @@ __metadata:
 
 "end-of-stream@npm:^1.4.1":
   version: 1.4.5
-  resolution: "end-of-stream@npm:1.4.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fend-of-stream%2F-%2Fend-of-stream-1.4.5.tgz"
+  resolution: "end-of-stream@npm:1.4.5"
   dependencies:
     once: "npm:^1.4.0"
   checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
@@ -4894,14 +4894,14 @@ __metadata:
 
 "engine.io-parser@npm:~5.2.1":
   version: 5.2.3
-  resolution: "engine.io-parser@npm:5.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fengine.io-parser%2F-%2Fengine.io-parser-5.2.3.tgz"
+  resolution: "engine.io-parser@npm:5.2.3"
   checksum: 10c0/ed4900d8dbef470ab3839ccf3bfa79ee518ea8277c7f1f2759e8c22a48f64e687ea5e474291394d0c94f84054749fd93f3ef0acb51fa2f5f234cc9d9d8e7c536
   languageName: node
   linkType: hard
 
 "engine.io@npm:~6.6.0":
   version: 6.6.5
-  resolution: "engine.io@npm:6.6.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fengine.io%2F-%2Fengine.io-6.6.5.tgz"
+  resolution: "engine.io@npm:6.6.5"
   dependencies:
     "@types/cors": "npm:^2.8.12"
     "@types/node": "npm:>=10.0.0"
@@ -4918,7 +4918,7 @@ __metadata:
 
 "enhanced-resolve@npm:5.12.0":
   version: 5.12.0
-  resolution: "enhanced-resolve@npm:5.12.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fenhanced-resolve%2F-%2Fenhanced-resolve-5.12.0.tgz"
+  resolution: "enhanced-resolve@npm:5.12.0"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
@@ -4928,7 +4928,7 @@ __metadata:
 
 "enquirer@npm:^2.4.1":
   version: 2.4.1
-  resolution: "enquirer@npm:2.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fenquirer%2F-%2Fenquirer-2.4.1.tgz"
+  resolution: "enquirer@npm:2.4.1"
   dependencies:
     ansi-colors: "npm:^4.1.1"
     strip-ansi: "npm:^6.0.1"
@@ -4938,28 +4938,28 @@ __metadata:
 
 "entities@npm:^4.2.0":
   version: 4.5.0
-  resolution: "entities@npm:4.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fentities%2F-%2Fentities-4.5.0.tgz"
+  resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
   languageName: node
   linkType: hard
 
 "entities@npm:^6.0.0":
   version: 6.0.1
-  resolution: "entities@npm:6.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fentities%2F-%2Fentities-6.0.1.tgz"
+  resolution: "entities@npm:6.0.1"
   checksum: 10c0/ed836ddac5acb34341094eb495185d527bd70e8632b6c0d59548cbfa23defdbae70b96f9a405c82904efa421230b5b3fd2283752447d737beffd3f3e6ee74414
   languageName: node
   linkType: hard
 
 "env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
   version: 2.2.1
-  resolution: "env-paths@npm:2.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fenv-paths%2F-%2Fenv-paths-2.2.1.tgz"
+  resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
   languageName: node
   linkType: hard
 
 "envinfo@npm:7.21.0":
   version: 7.21.0
-  resolution: "envinfo@npm:7.21.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fenvinfo%2F-%2Fenvinfo-7.21.0.tgz"
+  resolution: "envinfo@npm:7.21.0"
   bin:
     envinfo: dist/cli.js
   checksum: 10c0/4170127ca72dbf85be2c114f85558bd08178e8a43b394951ba9fd72d067c6fea3374df45a7b040e39e4e7b30bdd268e5bdf8661d99ae28302c2a88dedb41b5e6
@@ -4968,14 +4968,14 @@ __metadata:
 
 "err-code@npm:^2.0.2":
   version: 2.0.3
-  resolution: "err-code@npm:2.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ferr-code%2F-%2Ferr-code-2.0.3.tgz"
+  resolution: "err-code@npm:2.0.3"
   checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
   languageName: node
   linkType: hard
 
 "errno@npm:^0.1.1":
   version: 0.1.8
-  resolution: "errno@npm:0.1.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ferrno%2F-%2Ferrno-0.1.8.tgz"
+  resolution: "errno@npm:0.1.8"
   dependencies:
     prr: "npm:~1.0.1"
   bin:
@@ -4986,7 +4986,7 @@ __metadata:
 
 "error-ex@npm:^1.3.1":
   version: 1.3.4
-  resolution: "error-ex@npm:1.3.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ferror-ex%2F-%2Ferror-ex-1.3.4.tgz"
+  resolution: "error-ex@npm:1.3.4"
   dependencies:
     is-arrayish: "npm:^0.2.1"
   checksum: 10c0/b9e34ff4778b8f3b31a8377e1c654456f4c41aeaa3d10a1138c3b7635d8b7b2e03eb2475d46d8ae055c1f180a1063e100bffabf64ea7e7388b37735df5328664
@@ -4995,28 +4995,28 @@ __metadata:
 
 "es-define-property@npm:^1.0.1":
   version: 1.0.1
-  resolution: "es-define-property@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fes-define-property%2F-%2Fes-define-property-1.0.1.tgz"
+  resolution: "es-define-property@npm:1.0.1"
   checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
   languageName: node
   linkType: hard
 
 "es-errors@npm:^1.3.0":
   version: 1.3.0
-  resolution: "es-errors@npm:1.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fes-errors%2F-%2Fes-errors-1.3.0.tgz"
+  resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
   languageName: node
   linkType: hard
 
 "es-module-lexer@npm:^1.7.0":
   version: 1.7.0
-  resolution: "es-module-lexer@npm:1.7.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fes-module-lexer%2F-%2Fes-module-lexer-1.7.0.tgz"
+  resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
   languageName: node
   linkType: hard
 
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
-  resolution: "es-object-atoms@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fes-object-atoms%2F-%2Fes-object-atoms-1.1.1.tgz"
+  resolution: "es-object-atoms@npm:1.1.1"
   dependencies:
     es-errors: "npm:^1.3.0"
   checksum: 10c0/65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
@@ -5025,7 +5025,7 @@ __metadata:
 
 "es-set-tostringtag@npm:^2.1.0":
   version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fes-set-tostringtag%2F-%2Fes-set-tostringtag-2.1.0.tgz"
+  resolution: "es-set-tostringtag@npm:2.1.0"
   dependencies:
     es-errors: "npm:^1.3.0"
     get-intrinsic: "npm:^1.2.6"
@@ -5037,7 +5037,7 @@ __metadata:
 
 "es-toolkit@npm:^1.43.0":
   version: 1.44.0
-  resolution: "es-toolkit@npm:1.44.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fes-toolkit%2F-%2Fes-toolkit-1.44.0.tgz"
+  resolution: "es-toolkit@npm:1.44.0"
   dependenciesMeta:
     "@trivago/prettier-plugin-sort-imports@4.3.0":
       unplugged: true
@@ -5049,7 +5049,7 @@ __metadata:
 
 "esbuild-register@npm:^3.6.0":
   version: 3.6.0
-  resolution: "esbuild-register@npm:3.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fesbuild-register%2F-%2Fesbuild-register-3.6.0.tgz"
+  resolution: "esbuild-register@npm:3.6.0"
   dependencies:
     debug: "npm:^4.3.4"
   peerDependencies:
@@ -5060,7 +5060,7 @@ __metadata:
 
 "esbuild@npm:^0.25.12":
   version: 0.25.12
-  resolution: "esbuild@npm:0.25.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fesbuild%2F-%2Fesbuild-0.25.12.tgz"
+  resolution: "esbuild@npm:0.25.12"
   dependencies:
     "@esbuild/aix-ppc64": "npm:0.25.12"
     "@esbuild/android-arm": "npm:0.25.12"
@@ -5149,7 +5149,7 @@ __metadata:
 
 "esbuild@npm:^0.27.0":
   version: 0.27.2
-  resolution: "esbuild@npm:0.27.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fesbuild%2F-%2Fesbuild-0.27.2.tgz"
+  resolution: "esbuild@npm:0.27.2"
   dependencies:
     "@esbuild/aix-ppc64": "npm:0.27.2"
     "@esbuild/android-arm": "npm:0.27.2"
@@ -5238,42 +5238,42 @@ __metadata:
 
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
-  resolution: "escalade@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fescalade%2F-%2Fescalade-3.2.0.tgz"
+  resolution: "escalade@npm:3.2.0"
   checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
   languageName: node
   linkType: hard
 
 "escape-goat@npm:^4.0.0":
   version: 4.0.0
-  resolution: "escape-goat@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fescape-goat%2F-%2Fescape-goat-4.0.0.tgz"
+  resolution: "escape-goat@npm:4.0.0"
   checksum: 10c0/9d2a8314e2370f2dd9436d177f6b3b1773525df8f895c8f3e1acb716f5fd6b10b336cb1cd9862d4709b36eb207dbe33664838deca9c6d55b8371be4eebb972f6
   languageName: node
   linkType: hard
 
 "escape-html@npm:~1.0.3":
   version: 1.0.3
-  resolution: "escape-html@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fescape-html%2F-%2Fescape-html-1.0.3.tgz"
+  resolution: "escape-html@npm:1.0.3"
   checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
   languageName: node
   linkType: hard
 
 "escape-string-regexp@npm:*, escape-string-regexp@npm:^5.0.0":
   version: 5.0.0
-  resolution: "escape-string-regexp@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fescape-string-regexp%2F-%2Fescape-string-regexp-5.0.0.tgz"
+  resolution: "escape-string-regexp@npm:5.0.0"
   checksum: 10c0/6366f474c6f37a802800a435232395e04e9885919873e382b157ab7e8f0feb8fed71497f84a6f6a81a49aab41815522f5839112bd38026d203aea0c91622df95
   languageName: node
   linkType: hard
 
 "escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
-  resolution: "escape-string-regexp@npm:1.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fescape-string-regexp%2F-%2Fescape-string-regexp-1.0.5.tgz"
+  resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
   languageName: node
   linkType: hard
 
 "esprima@npm:^4.0.0":
   version: 4.0.1
-  resolution: "esprima@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fesprima%2F-%2Fesprima-4.0.1.tgz"
+  resolution: "esprima@npm:4.0.1"
   bin:
     esparse: ./bin/esparse.js
     esvalidate: ./bin/esvalidate.js
@@ -5283,7 +5283,7 @@ __metadata:
 
 "estree-walker@npm:^3.0.0, estree-walker@npm:^3.0.3":
   version: 3.0.3
-  resolution: "estree-walker@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Festree-walker%2F-%2Festree-walker-3.0.3.tgz"
+  resolution: "estree-walker@npm:3.0.3"
   dependencies:
     "@types/estree": "npm:^1.0.0"
   checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
@@ -5292,21 +5292,21 @@ __metadata:
 
 "etag@npm:~1.8.1":
   version: 1.8.1
-  resolution: "etag@npm:1.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fetag%2F-%2Fetag-1.8.1.tgz"
+  resolution: "etag@npm:1.8.1"
   checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
   languageName: node
   linkType: hard
 
 "event-target-shim@npm:^5.0.0":
   version: 5.0.1
-  resolution: "event-target-shim@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fevent-target-shim%2F-%2Fevent-target-shim-5.0.1.tgz"
+  resolution: "event-target-shim@npm:5.0.1"
   checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
   languageName: node
   linkType: hard
 
 "execa@npm:^8.0.1":
   version: 8.0.1
-  resolution: "execa@npm:8.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexeca%2F-%2Fexeca-8.0.1.tgz"
+  resolution: "execa@npm:8.0.1"
   dependencies:
     cross-spawn: "npm:^7.0.3"
     get-stream: "npm:^8.0.1"
@@ -5323,28 +5323,28 @@ __metadata:
 
 "exit-hook@npm:^4.0.0":
   version: 4.0.0
-  resolution: "exit-hook@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexit-hook%2F-%2Fexit-hook-4.0.0.tgz"
+  resolution: "exit-hook@npm:4.0.0"
   checksum: 10c0/7fb33eaeb9050aee9479da9c93d42b796fb409c40e1d2b6ea2f40786ae7d7db6dc6a0f6ecc7bc24e479f957b7844bcb880044ded73320334743c64e3ecef48d7
   languageName: node
   linkType: hard
 
 "expect-type@npm:^1.2.2":
   version: 1.3.0
-  resolution: "expect-type@npm:1.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexpect-type%2F-%2Fexpect-type-1.3.0.tgz"
+  resolution: "expect-type@npm:1.3.0"
   checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.3
-  resolution: "exponential-backoff@npm:3.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexponential-backoff%2F-%2Fexponential-backoff-3.1.3.tgz"
+  resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
   languageName: node
   linkType: hard
 
 "express-session@npm:^1.18.0":
   version: 1.19.0
-  resolution: "express-session@npm:1.19.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexpress-session%2F-%2Fexpress-session-1.19.0.tgz"
+  resolution: "express-session@npm:1.19.0"
   dependencies:
     cookie: "npm:~0.7.2"
     cookie-signature: "npm:~1.0.7"
@@ -5360,7 +5360,7 @@ __metadata:
 
 "express@npm:^4.18.3":
   version: 4.22.1
-  resolution: "express@npm:4.22.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexpress%2F-%2Fexpress-4.22.1.tgz"
+  resolution: "express@npm:4.22.1"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
@@ -5399,21 +5399,21 @@ __metadata:
 
 "extend@npm:^3.0.2":
   version: 3.0.2
-  resolution: "extend@npm:3.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fextend%2F-%2Fextend-3.0.2.tgz"
+  resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
   languageName: node
   linkType: hard
 
 "extendable-error@npm:^0.1.5":
   version: 0.1.7
-  resolution: "extendable-error@npm:0.1.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fextendable-error%2F-%2Fextendable-error-0.1.7.tgz"
+  resolution: "extendable-error@npm:0.1.7"
   checksum: 10c0/c46648b7682448428f81b157cbfe480170fd96359c55db477a839ddeaa34905a18cba0b989bafe5e83f93c2491a3fcc7cc536063ea326ba9d72e9c6e2fe736a7
   languageName: node
   linkType: hard
 
 "external-editor@npm:^3.0.3":
   version: 3.1.0
-  resolution: "external-editor@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexternal-editor%2F-%2Fexternal-editor-3.1.0.tgz"
+  resolution: "external-editor@npm:3.1.0"
   dependencies:
     chardet: "npm:^0.7.0"
     iconv-lite: "npm:^0.4.24"
@@ -5424,21 +5424,21 @@ __metadata:
 
 "farmhash-modern@npm:^1.1.0":
   version: 1.1.0
-  resolution: "farmhash-modern@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffarmhash-modern%2F-%2Ffarmhash-modern-1.1.0.tgz"
+  resolution: "farmhash-modern@npm:1.1.0"
   checksum: 10c0/eca8a1e40e5ca78395d585298f813f8e33ef884624795969ac708d7b855ab9a7e543d31fc14ba715bc7aa302d464e1db6ddc38e6c87816ed8f5a75db482d7071
   languageName: node
   linkType: hard
 
 "fast-deep-equal@npm:^3.1.1":
   version: 3.1.3
-  resolution: "fast-deep-equal@npm:3.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffast-deep-equal%2F-%2Ffast-deep-equal-3.1.3.tgz"
+  resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
   languageName: node
   linkType: hard
 
 "fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
   version: 3.3.3
-  resolution: "fast-glob@npm:3.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffast-glob%2F-%2Ffast-glob-3.3.3.tgz"
+  resolution: "fast-glob@npm:3.3.3"
   dependencies:
     "@nodelib/fs.stat": "npm:^2.0.2"
     "@nodelib/fs.walk": "npm:^1.2.3"
@@ -5451,14 +5451,14 @@ __metadata:
 
 "fast-safe-stringify@npm:^2.1.1":
   version: 2.1.1
-  resolution: "fast-safe-stringify@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffast-safe-stringify%2F-%2Ffast-safe-stringify-2.1.1.tgz"
+  resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
   languageName: node
   linkType: hard
 
 "fast-xml-parser@npm:^4.4.1":
   version: 4.5.3
-  resolution: "fast-xml-parser@npm:4.5.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffast-xml-parser%2F-%2Ffast-xml-parser-4.5.3.tgz"
+  resolution: "fast-xml-parser@npm:4.5.3"
   dependencies:
     strnum: "npm:^1.1.1"
   bin:
@@ -5469,7 +5469,7 @@ __metadata:
 
 "fastq@npm:^1.6.0":
   version: 1.20.1
-  resolution: "fastq@npm:1.20.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffastq%2F-%2Ffastq-1.20.1.tgz"
+  resolution: "fastq@npm:1.20.1"
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10c0/e5dd725884decb1f11e5c822221d76136f239d0236f176fab80b7b8f9e7619ae57e6b4e5b73defc21e6b9ef99437ee7b545cff8e6c2c337819633712fa9d352e
@@ -5478,7 +5478,7 @@ __metadata:
 
 "faye-websocket@npm:0.11.4":
   version: 0.11.4
-  resolution: "faye-websocket@npm:0.11.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffaye-websocket%2F-%2Ffaye-websocket-0.11.4.tgz"
+  resolution: "faye-websocket@npm:0.11.4"
   dependencies:
     websocket-driver: "npm:>=0.5.1"
   checksum: 10c0/c6052a0bb322778ce9f89af92890f6f4ce00d5ec92418a35e5f4c6864a4fe736fec0bcebd47eac7c0f0e979b01530746b1c85c83cb04bae789271abf19737420
@@ -5487,7 +5487,7 @@ __metadata:
 
 "fdir@npm:^6.5.0":
   version: 6.5.0
-  resolution: "fdir@npm:6.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffdir%2F-%2Ffdir-6.5.0.tgz"
+  resolution: "fdir@npm:6.5.0"
   peerDependencies:
     picomatch: ^3 || ^4
   peerDependenciesMeta:
@@ -5499,14 +5499,14 @@ __metadata:
 
 "fflate@npm:^0.8.2":
   version: 0.8.2
-  resolution: "fflate@npm:0.8.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffflate%2F-%2Ffflate-0.8.2.tgz"
+  resolution: "fflate@npm:0.8.2"
   checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
   languageName: node
   linkType: hard
 
 "figures@npm:^1.7.0":
   version: 1.7.0
-  resolution: "figures@npm:1.7.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffigures%2F-%2Ffigures-1.7.0.tgz"
+  resolution: "figures@npm:1.7.0"
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
     object-assign: "npm:^4.1.0"
@@ -5516,7 +5516,7 @@ __metadata:
 
 "figures@npm:^2.0.0":
   version: 2.0.0
-  resolution: "figures@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffigures%2F-%2Ffigures-2.0.0.tgz"
+  resolution: "figures@npm:2.0.0"
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 10c0/5dc5a75fec3e7e04ae65d6ce51d28b3e70d4656c51b06996b6fdb2cb5b542df512e3b3c04482f5193a964edddafa5521479ff948fa84e12ff556e53e094ab4ce
@@ -5525,7 +5525,7 @@ __metadata:
 
 "figures@npm:^3.0.0":
   version: 3.2.0
-  resolution: "figures@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffigures%2F-%2Ffigures-3.2.0.tgz"
+  resolution: "figures@npm:3.2.0"
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 10c0/9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
@@ -5534,14 +5534,14 @@ __metadata:
 
 "filesize@npm:^10.1.6":
   version: 10.1.6
-  resolution: "filesize@npm:10.1.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffilesize%2F-%2Ffilesize-10.1.6.tgz"
+  resolution: "filesize@npm:10.1.6"
   checksum: 10c0/9a196d64da4e947b8c0d294be09a3dfa7a634434a1fc5fb3465f1c9acc1237ea0363f245ba6e24477ea612754d942bc964d86e0e500905a72e9e0e17ae1bbdbc
   languageName: node
   linkType: hard
 
 "fill-range@npm:^7.1.1":
   version: 7.1.1
-  resolution: "fill-range@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffill-range%2F-%2Ffill-range-7.1.1.tgz"
+  resolution: "fill-range@npm:7.1.1"
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
@@ -5550,7 +5550,7 @@ __metadata:
 
 "finalhandler@npm:~1.3.1":
   version: 1.3.2
-  resolution: "finalhandler@npm:1.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffinalhandler%2F-%2Ffinalhandler-1.3.2.tgz"
+  resolution: "finalhandler@npm:1.3.2"
   dependencies:
     debug: "npm:2.6.9"
     encodeurl: "npm:~2.0.0"
@@ -5565,14 +5565,14 @@ __metadata:
 
 "find-up-simple@npm:^1.0.0":
   version: 1.0.1
-  resolution: "find-up-simple@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffind-up-simple%2F-%2Ffind-up-simple-1.0.1.tgz"
+  resolution: "find-up-simple@npm:1.0.1"
   checksum: 10c0/ad34de157b7db925d50ff78302fefb28e309f3bc947c93ffca0f9b0bccf9cf1a2dc57d805d5c94ec9fc60f4838f5dbdfd2a48ecd77c23015fa44c6dd5f60bc40
   languageName: node
   linkType: hard
 
 "find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
-  resolution: "find-up@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffind-up%2F-%2Ffind-up-4.1.0.tgz"
+  resolution: "find-up@npm:4.1.0"
   dependencies:
     locate-path: "npm:^5.0.0"
     path-exists: "npm:^4.0.0"
@@ -5582,7 +5582,7 @@ __metadata:
 
 "firebase-admin@npm:^13.6.0":
   version: 13.6.0
-  resolution: "firebase-admin@npm:13.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffirebase-admin%2F-%2Ffirebase-admin-13.6.0.tgz"
+  resolution: "firebase-admin@npm:13.6.0"
   dependencies:
     "@fastify/busboy": "npm:^3.0.0"
     "@firebase/database-compat": "npm:^2.0.0"
@@ -5608,21 +5608,21 @@ __metadata:
 
 "flatted@npm:^3.3.3":
   version: 3.3.3
-  resolution: "flatted@npm:3.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fflatted%2F-%2Fflatted-3.3.3.tgz"
+  resolution: "flatted@npm:3.3.3"
   checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
   languageName: node
   linkType: hard
 
 "foreachasync@npm:^3.0.0":
   version: 3.0.0
-  resolution: "foreachasync@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fforeachasync%2F-%2Fforeachasync-3.0.0.tgz"
+  resolution: "foreachasync@npm:3.0.0"
   checksum: 10c0/8ad877008da351fa78939e850c6014e94b8b9c6de3d12751b2b906ef96f8c80945310d998b2a704854e126c508237dc9951f6900685ccc42c93db15b09a0c4b3
   languageName: node
   linkType: hard
 
 "form-data@npm:^2.5.5":
   version: 2.5.5
-  resolution: "form-data@npm:2.5.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fform-data%2F-%2Fform-data-2.5.5.tgz"
+  resolution: "form-data@npm:2.5.5"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
@@ -5636,7 +5636,7 @@ __metadata:
 
 "formidable@npm:^2.0.1":
   version: 2.1.5
-  resolution: "formidable@npm:2.1.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fformidable%2F-%2Fformidable-2.1.5.tgz"
+  resolution: "formidable@npm:2.1.5"
   dependencies:
     "@paralleldrive/cuid2": "npm:^2.2.2"
     dezalgo: "npm:^1.0.4"
@@ -5648,21 +5648,21 @@ __metadata:
 
 "forwarded@npm:0.2.0":
   version: 0.2.0
-  resolution: "forwarded@npm:0.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fforwarded%2F-%2Fforwarded-0.2.0.tgz"
+  resolution: "forwarded@npm:0.2.0"
   checksum: 10c0/9b67c3fac86acdbc9ae47ba1ddd5f2f81526fa4c8226863ede5600a3f7c7416ef451f6f1e240a3cc32d0fd79fcfe6beb08fd0da454f360032bde70bf80afbb33
   languageName: node
   linkType: hard
 
 "fresh@npm:~0.5.2":
   version: 0.5.2
-  resolution: "fresh@npm:0.5.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffresh%2F-%2Ffresh-0.5.2.tgz"
+  resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
   languageName: node
   linkType: hard
 
 "fs-extra@npm:^11.1.1":
   version: 11.3.3
-  resolution: "fs-extra@npm:11.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs-extra%2F-%2Ffs-extra-11.3.3.tgz"
+  resolution: "fs-extra@npm:11.3.3"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^6.0.1"
@@ -5673,7 +5673,7 @@ __metadata:
 
 "fs-extra@npm:^7.0.1":
   version: 7.0.1
-  resolution: "fs-extra@npm:7.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs-extra%2F-%2Ffs-extra-7.0.1.tgz"
+  resolution: "fs-extra@npm:7.0.1"
   dependencies:
     graceful-fs: "npm:^4.1.2"
     jsonfile: "npm:^4.0.0"
@@ -5684,7 +5684,7 @@ __metadata:
 
 "fs-extra@npm:^8.1.0":
   version: 8.1.0
-  resolution: "fs-extra@npm:8.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs-extra%2F-%2Ffs-extra-8.1.0.tgz"
+  resolution: "fs-extra@npm:8.1.0"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^4.0.0"
@@ -5695,7 +5695,7 @@ __metadata:
 
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
-  resolution: "fs-minipass@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs-minipass%2F-%2Ffs-minipass-3.0.3.tgz"
+  resolution: "fs-minipass@npm:3.0.3"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/63e80da2ff9b621e2cb1596abcb9207f1cf82b968b116ccd7b959e3323144cce7fb141462200971c38bbf2ecca51695069db45265705bed09a7cd93ae5b89f94
@@ -5704,14 +5704,14 @@ __metadata:
 
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
-  resolution: "fs.realpath@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs.realpath%2F-%2Ffs.realpath-1.0.0.tgz"
+  resolution: "fs.realpath@npm:1.0.0"
   checksum: 10c0/444cf1291d997165dfd4c0d58b69f0e4782bfd9149fd72faa4fe299e68e0e93d6db941660b37dd29153bf7186672ececa3b50b7e7249477b03fdf850f287c948
   languageName: node
   linkType: hard
 
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
-  resolution: "fsevents@npm:2.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffsevents%2F-%2Ffsevents-2.3.3.tgz"
+  resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
@@ -5721,7 +5721,7 @@ __metadata:
 
 "fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.3%3A%3A__archiveUrl=https%253A%252F%252Fpackages.atlassian.com%252Fapi%252Fnpm%252Fnpm-remote%252Ffsevents%252F-%252Ffsevents-2.3.3.tgz#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
@@ -5730,21 +5730,21 @@ __metadata:
 
 "function-bind@npm:^1.1.2":
   version: 1.1.2
-  resolution: "function-bind@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffunction-bind%2F-%2Ffunction-bind-1.1.2.tgz"
+  resolution: "function-bind@npm:1.1.2"
   checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
   languageName: node
   linkType: hard
 
 "functional-red-black-tree@npm:^1.0.1":
   version: 1.0.1
-  resolution: "functional-red-black-tree@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffunctional-red-black-tree%2F-%2Ffunctional-red-black-tree-1.0.1.tgz"
+  resolution: "functional-red-black-tree@npm:1.0.1"
   checksum: 10c0/5959eed0375803d9924f47688479bb017e0c6816a0e5ac151e22ba6bfe1d12c41de2f339188885e0aa8eeea2072dad509d8e4448467e816bde0a2ca86a0670d3
   languageName: node
   linkType: hard
 
 "gauge@npm:^5.0.0":
   version: 5.0.2
-  resolution: "gauge@npm:5.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgauge%2F-%2Fgauge-5.0.2.tgz"
+  resolution: "gauge@npm:5.0.2"
   dependencies:
     aproba: "npm:^1.0.3 || ^2.0.0"
     color-support: "npm:^1.1.3"
@@ -5760,7 +5760,7 @@ __metadata:
 
 "gaxios@npm:^6.0.0, gaxios@npm:^6.0.2, gaxios@npm:^6.1.1":
   version: 6.7.1
-  resolution: "gaxios@npm:6.7.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgaxios%2F-%2Fgaxios-6.7.1.tgz"
+  resolution: "gaxios@npm:6.7.1"
   dependencies:
     extend: "npm:^3.0.2"
     https-proxy-agent: "npm:^7.0.1"
@@ -5773,7 +5773,7 @@ __metadata:
 
 "gcp-metadata@npm:^6.1.0":
   version: 6.1.1
-  resolution: "gcp-metadata@npm:6.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgcp-metadata%2F-%2Fgcp-metadata-6.1.1.tgz"
+  resolution: "gcp-metadata@npm:6.1.1"
   dependencies:
     gaxios: "npm:^6.1.1"
     google-logging-utils: "npm:^0.0.2"
@@ -5784,35 +5784,35 @@ __metadata:
 
 "generator-function@npm:^2.0.0":
   version: 2.0.1
-  resolution: "generator-function@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgenerator-function%2F-%2Fgenerator-function-2.0.1.tgz"
+  resolution: "generator-function@npm:2.0.1"
   checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
   languageName: node
   linkType: hard
 
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
-  resolution: "gensync@npm:1.0.0-beta.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgensync%2F-%2Fgensync-1.0.0-beta.2.tgz"
+  resolution: "gensync@npm:1.0.0-beta.2"
   checksum: 10c0/782aba6cba65b1bb5af3b095d96249d20edbe8df32dbf4696fd49be2583faf676173bf4809386588828e4dd76a3354fcbeb577bab1c833ccd9fc4577f26103f8
   languageName: node
   linkType: hard
 
 "get-caller-file@npm:^2.0.5":
   version: 2.0.5
-  resolution: "get-caller-file@npm:2.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fget-caller-file%2F-%2Fget-caller-file-2.0.5.tgz"
+  resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
   languageName: node
   linkType: hard
 
 "get-east-asian-width@npm:^1.0.0":
   version: 1.4.0
-  resolution: "get-east-asian-width@npm:1.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fget-east-asian-width%2F-%2Fget-east-asian-width-1.4.0.tgz"
+  resolution: "get-east-asian-width@npm:1.4.0"
   checksum: 10c0/4e481d418e5a32061c36fbb90d1b225a254cc5b2df5f0b25da215dcd335a3c111f0c2023ffda43140727a9cafb62dac41d022da82c08f31083ee89f714ee3b83
   languageName: node
   linkType: hard
 
 "get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
-  resolution: "get-intrinsic@npm:1.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fget-intrinsic%2F-%2Fget-intrinsic-1.3.1.tgz"
+  resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
     async-function: "npm:^1.0.0"
     async-generator-function: "npm:^1.0.0"
@@ -5833,14 +5833,14 @@ __metadata:
 
 "get-port@npm:5.1.1":
   version: 5.1.1
-  resolution: "get-port@npm:5.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fget-port%2F-%2Fget-port-5.1.1.tgz"
+  resolution: "get-port@npm:5.1.1"
   checksum: 10c0/2873877a469b24e6d5e0be490724a17edb39fafc795d1d662e7bea951ca649713b4a50117a473f9d162312cb0e946597bd0e049ed2f866e79e576e8e213d3d1c
   languageName: node
   linkType: hard
 
 "get-proto@npm:^1.0.1":
   version: 1.0.1
-  resolution: "get-proto@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fget-proto%2F-%2Fget-proto-1.0.1.tgz"
+  resolution: "get-proto@npm:1.0.1"
   dependencies:
     dunder-proto: "npm:^1.0.1"
     es-object-atoms: "npm:^1.0.0"
@@ -5850,21 +5850,21 @@ __metadata:
 
 "get-stream@npm:^8.0.1":
   version: 8.0.1
-  resolution: "get-stream@npm:8.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fget-stream%2F-%2Fget-stream-8.0.1.tgz"
+  resolution: "get-stream@npm:8.0.1"
   checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
   languageName: node
   linkType: hard
 
 "github-url-from-git@npm:^1.5.0":
   version: 1.5.0
-  resolution: "github-url-from-git@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgithub-url-from-git%2F-%2Fgithub-url-from-git-1.5.0.tgz"
+  resolution: "github-url-from-git@npm:1.5.0"
   checksum: 10c0/d9af476188a660a289f7f2a32d6f25e5199dc04a31ac6f5b4e0c3749cd0b42db9768571cd72659ecf5cb98ca687a14dc43da315c7b52e53c21702ff534012b28
   languageName: node
   linkType: hard
 
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
-  resolution: "glob-parent@npm:5.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglob-parent%2F-%2Fglob-parent-5.1.2.tgz"
+  resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: "npm:^4.0.1"
   checksum: 10c0/cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
@@ -5873,7 +5873,7 @@ __metadata:
 
 "glob@npm:^13.0.0":
   version: 13.0.0
-  resolution: "glob@npm:13.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglob%2F-%2Fglob-13.0.0.tgz"
+  resolution: "glob@npm:13.0.0"
   dependencies:
     minimatch: "npm:^10.1.1"
     minipass: "npm:^7.1.2"
@@ -5884,7 +5884,7 @@ __metadata:
 
 "glob@npm:^7.1.3":
   version: 7.2.3
-  resolution: "glob@npm:7.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglob%2F-%2Fglob-7.2.3.tgz"
+  resolution: "glob@npm:7.2.3"
   dependencies:
     fs.realpath: "npm:^1.0.0"
     inflight: "npm:^1.0.4"
@@ -5898,7 +5898,7 @@ __metadata:
 
 "global-directory@npm:^4.0.1":
   version: 4.0.1
-  resolution: "global-directory@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglobal-directory%2F-%2Fglobal-directory-4.0.1.tgz"
+  resolution: "global-directory@npm:4.0.1"
   dependencies:
     ini: "npm:4.1.1"
   checksum: 10c0/f9cbeef41db4876f94dd0bac1c1b4282a7de9c16350ecaaf83e7b2dd777b32704cc25beeb1170b5a63c42a2c9abfade74d46357fe0133e933218bc89e613d4b2
@@ -5907,7 +5907,7 @@ __metadata:
 
 "globby@npm:^11.0.0":
   version: 11.1.0
-  resolution: "globby@npm:11.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglobby%2F-%2Fglobby-11.1.0.tgz"
+  resolution: "globby@npm:11.1.0"
   dependencies:
     array-union: "npm:^2.1.0"
     dir-glob: "npm:^3.0.1"
@@ -5921,7 +5921,7 @@ __metadata:
 
 "globby@npm:^14.0.2":
   version: 14.1.0
-  resolution: "globby@npm:14.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglobby%2F-%2Fglobby-14.1.0.tgz"
+  resolution: "globby@npm:14.1.0"
   dependencies:
     "@sindresorhus/merge-streams": "npm:^2.1.0"
     fast-glob: "npm:^3.3.3"
@@ -5935,7 +5935,7 @@ __metadata:
 
 "google-auth-library@npm:^9.14.2, google-auth-library@npm:^9.3.0, google-auth-library@npm:^9.6.3":
   version: 9.15.1
-  resolution: "google-auth-library@npm:9.15.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgoogle-auth-library%2F-%2Fgoogle-auth-library-9.15.1.tgz"
+  resolution: "google-auth-library@npm:9.15.1"
   dependencies:
     base64-js: "npm:^1.3.0"
     ecdsa-sig-formatter: "npm:^1.0.11"
@@ -5949,7 +5949,7 @@ __metadata:
 
 "google-gax@npm:^4.3.3":
   version: 4.6.1
-  resolution: "google-gax@npm:4.6.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgoogle-gax%2F-%2Fgoogle-gax-4.6.1.tgz"
+  resolution: "google-gax@npm:4.6.1"
   dependencies:
     "@grpc/grpc-js": "npm:^1.10.9"
     "@grpc/proto-loader": "npm:^0.7.13"
@@ -5969,35 +5969,35 @@ __metadata:
 
 "google-logging-utils@npm:^0.0.2":
   version: 0.0.2
-  resolution: "google-logging-utils@npm:0.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgoogle-logging-utils%2F-%2Fgoogle-logging-utils-0.0.2.tgz"
+  resolution: "google-logging-utils@npm:0.0.2"
   checksum: 10c0/9a4bbd470dd101c77405e450fffca8592d1d7114f245a121288d04a957aca08c9dea2dd1a871effe71e41540d1bb0494731a0b0f6fea4358e77f06645e4268c1
   languageName: node
   linkType: hard
 
 "gopd@npm:^1.2.0":
   version: 1.2.0
-  resolution: "gopd@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgopd%2F-%2Fgopd-1.2.0.tgz"
+  resolution: "gopd@npm:1.2.0"
   checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
   languageName: node
   linkType: hard
 
 "graceful-fs@npm:4.2.10":
   version: 4.2.10
-  resolution: "graceful-fs@npm:4.2.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgraceful-fs%2F-%2Fgraceful-fs-4.2.10.tgz"
+  resolution: "graceful-fs@npm:4.2.10"
   checksum: 10c0/4223a833e38e1d0d2aea630c2433cfb94ddc07dfc11d511dbd6be1d16688c5be848acc31f9a5d0d0ddbfb56d2ee5a6ae0278aceeb0ca6a13f27e06b9956fb952
   languageName: node
   linkType: hard
 
 "graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.5, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
-  resolution: "graceful-fs@npm:4.2.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgraceful-fs%2F-%2Fgraceful-fs-4.2.11.tgz"
+  resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
   languageName: node
   linkType: hard
 
 "gtoken@npm:^7.0.0":
   version: 7.1.0
-  resolution: "gtoken@npm:7.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgtoken%2F-%2Fgtoken-7.1.0.tgz"
+  resolution: "gtoken@npm:7.1.0"
   dependencies:
     gaxios: "npm:^6.0.0"
     jws: "npm:^4.0.0"
@@ -6007,7 +6007,7 @@ __metadata:
 
 "handlebars@npm:4.7.7":
   version: 4.7.7
-  resolution: "handlebars@npm:4.7.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhandlebars%2F-%2Fhandlebars-4.7.7.tgz"
+  resolution: "handlebars@npm:4.7.7"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.0"
@@ -6025,7 +6025,7 @@ __metadata:
 
 "has-ansi@npm:^2.0.0":
   version: 2.0.0
-  resolution: "has-ansi@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhas-ansi%2F-%2Fhas-ansi-2.0.0.tgz"
+  resolution: "has-ansi@npm:2.0.0"
   dependencies:
     ansi-regex: "npm:^2.0.0"
   checksum: 10c0/f54e4887b9f8f3c4bfefd649c48825b3c093987c92c27880ee9898539e6f01aed261e82e73153c3f920fde0db5bf6ebd58deb498ed1debabcb4bc40113ccdf05
@@ -6034,28 +6034,28 @@ __metadata:
 
 "has-flag@npm:^3.0.0":
   version: 3.0.0
-  resolution: "has-flag@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz"
+  resolution: "has-flag@npm:3.0.0"
   checksum: 10c0/1c6c83b14b8b1b3c25b0727b8ba3e3b647f99e9e6e13eb7322107261de07a4c1be56fc0d45678fc376e09772a3a1642ccdaf8fc69bdf123b6c086598397ce473
   languageName: node
   linkType: hard
 
 "has-flag@npm:^4.0.0":
   version: 4.0.0
-  resolution: "has-flag@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhas-flag%2F-%2Fhas-flag-4.0.0.tgz"
+  resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
   languageName: node
   linkType: hard
 
 "has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
-  resolution: "has-symbols@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhas-symbols%2F-%2Fhas-symbols-1.1.0.tgz"
+  resolution: "has-symbols@npm:1.1.0"
   checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
   languageName: node
   linkType: hard
 
 "has-tostringtag@npm:^1.0.2":
   version: 1.0.2
-  resolution: "has-tostringtag@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhas-tostringtag%2F-%2Fhas-tostringtag-1.0.2.tgz"
+  resolution: "has-tostringtag@npm:1.0.2"
   dependencies:
     has-symbols: "npm:^1.0.3"
   checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
@@ -6064,14 +6064,14 @@ __metadata:
 
 "has-unicode@npm:^2.0.1":
   version: 2.0.1
-  resolution: "has-unicode@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhas-unicode%2F-%2Fhas-unicode-2.0.1.tgz"
+  resolution: "has-unicode@npm:2.0.1"
   checksum: 10c0/ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
   languageName: node
   linkType: hard
 
 "hasown@npm:^2.0.2":
   version: 2.0.2
-  resolution: "hasown@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhasown%2F-%2Fhasown-2.0.2.tgz"
+  resolution: "hasown@npm:2.0.2"
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
@@ -6080,7 +6080,7 @@ __metadata:
 
 "hbs@npm:^4.2.0":
   version: 4.2.0
-  resolution: "hbs@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhbs%2F-%2Fhbs-4.2.0.tgz"
+  resolution: "hbs@npm:4.2.0"
   dependencies:
     handlebars: "npm:4.7.7"
     walk: "npm:2.3.15"
@@ -6090,14 +6090,14 @@ __metadata:
 
 "helmet@npm:^7.1.0":
   version: 7.2.0
-  resolution: "helmet@npm:7.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhelmet%2F-%2Fhelmet-7.2.0.tgz"
+  resolution: "helmet@npm:7.2.0"
   checksum: 10c0/7ba8503519cabc1d6410330b710da3ac01a4ff66e7e10cb68c4d73c96803a2e86ce45c71f3127dfb8ef3ea2e91c7b8316726191873f80d0572f8826878b2854e
   languageName: node
   linkType: hard
 
 "hosted-git-info@npm:^7.0.0":
   version: 7.0.2
-  resolution: "hosted-git-info@npm:7.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhosted-git-info%2F-%2Fhosted-git-info-7.0.2.tgz"
+  resolution: "hosted-git-info@npm:7.0.2"
   dependencies:
     lru-cache: "npm:^10.0.1"
   checksum: 10c0/b19dbd92d3c0b4b0f1513cf79b0fc189f54d6af2129eeb201de2e9baaa711f1936929c848b866d9c8667a0f956f34bf4f07418c12be1ee9ca74fd9246335ca1f
@@ -6106,7 +6106,7 @@ __metadata:
 
 "hosted-git-info@npm:^8.0.2":
   version: 8.1.0
-  resolution: "hosted-git-info@npm:8.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhosted-git-info%2F-%2Fhosted-git-info-8.1.0.tgz"
+  resolution: "hosted-git-info@npm:8.1.0"
   dependencies:
     lru-cache: "npm:^10.0.1"
   checksum: 10c0/53cc838ecaa7d4aa69a81d9d8edc362c9d415f67b76ad38cdd781d2a2f5b45ad0aa9f9b013fb4ea54a9f64fd2365d0b6386b5a24bdf4cb90c80477cf3175aaa2
@@ -6115,21 +6115,21 @@ __metadata:
 
 "html-entities@npm:^2.5.2":
   version: 2.6.0
-  resolution: "html-entities@npm:2.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhtml-entities%2F-%2Fhtml-entities-2.6.0.tgz"
+  resolution: "html-entities@npm:2.6.0"
   checksum: 10c0/7c8b15d9ea0cd00dc9279f61bab002ba6ca8a7a0f3c36ed2db3530a67a9621c017830d1d2c1c65beb9b8e3436ea663e9cf8b230472e0e413359399413b27c8b7
   languageName: node
   linkType: hard
 
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
-  resolution: "html-escaper@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhtml-escaper%2F-%2Fhtml-escaper-2.0.2.tgz"
+  resolution: "html-escaper@npm:2.0.2"
   checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
   languageName: node
   linkType: hard
 
 "htmlparser2@npm:10.0.0":
   version: 10.0.0
-  resolution: "htmlparser2@npm:10.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhtmlparser2%2F-%2Fhtmlparser2-10.0.0.tgz"
+  resolution: "htmlparser2@npm:10.0.0"
   dependencies:
     domelementtype: "npm:^2.3.0"
     domhandler: "npm:^5.0.3"
@@ -6141,14 +6141,14 @@ __metadata:
 
 "http-cache-semantics@npm:^4.1.1":
   version: 4.2.0
-  resolution: "http-cache-semantics@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-cache-semantics%2F-%2Fhttp-cache-semantics-4.2.0.tgz"
+  resolution: "http-cache-semantics@npm:4.2.0"
   checksum: 10c0/45b66a945cf13ec2d1f29432277201313babf4a01d9e52f44b31ca923434083afeca03f18417f599c9ab3d0e7b618ceb21257542338b57c54b710463b4a53e37
   languageName: node
   linkType: hard
 
 "http-errors@npm:~1.7.3":
   version: 1.7.3
-  resolution: "http-errors@npm:1.7.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-errors%2F-%2Fhttp-errors-1.7.3.tgz"
+  resolution: "http-errors@npm:1.7.3"
   dependencies:
     depd: "npm:~1.1.2"
     inherits: "npm:2.0.4"
@@ -6161,7 +6161,7 @@ __metadata:
 
 "http-errors@npm:~1.8.0":
   version: 1.8.1
-  resolution: "http-errors@npm:1.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-errors%2F-%2Fhttp-errors-1.8.1.tgz"
+  resolution: "http-errors@npm:1.8.1"
   dependencies:
     depd: "npm:~1.1.2"
     inherits: "npm:2.0.4"
@@ -6174,7 +6174,7 @@ __metadata:
 
 "http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
-  resolution: "http-errors@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-errors%2F-%2Fhttp-errors-2.0.1.tgz"
+  resolution: "http-errors@npm:2.0.1"
   dependencies:
     depd: "npm:~2.0.0"
     inherits: "npm:~2.0.4"
@@ -6187,14 +6187,14 @@ __metadata:
 
 "http-parser-js@npm:>=0.5.1":
   version: 0.5.10
-  resolution: "http-parser-js@npm:0.5.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-parser-js%2F-%2Fhttp-parser-js-0.5.10.tgz"
+  resolution: "http-parser-js@npm:0.5.10"
   checksum: 10c0/8bbcf1832a8d70b2bd515270112116333add88738a2cc05bfb94ba6bde3be4b33efee5611584113818d2bcf654fdc335b652503be5a6b4c0b95e46f214187d93
   languageName: node
   linkType: hard
 
 "http-proxy-agent@npm:^5.0.0":
   version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-proxy-agent%2F-%2Fhttp-proxy-agent-5.0.0.tgz"
+  resolution: "http-proxy-agent@npm:5.0.0"
   dependencies:
     "@tootallnate/once": "npm:2"
     agent-base: "npm:6"
@@ -6205,7 +6205,7 @@ __metadata:
 
 "http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
-  resolution: "http-proxy-agent@npm:7.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttp-proxy-agent%2F-%2Fhttp-proxy-agent-7.0.2.tgz"
+  resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
     agent-base: "npm:^7.1.0"
     debug: "npm:^4.3.4"
@@ -6215,7 +6215,7 @@ __metadata:
 
 "https-proxy-agent@npm:^5.0.0":
   version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttps-proxy-agent%2F-%2Fhttps-proxy-agent-5.0.1.tgz"
+  resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
     agent-base: "npm:6"
     debug: "npm:4"
@@ -6225,7 +6225,7 @@ __metadata:
 
 "https-proxy-agent@npm:^7.0.1":
   version: 7.0.6
-  resolution: "https-proxy-agent@npm:7.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhttps-proxy-agent%2F-%2Fhttps-proxy-agent-7.0.6.tgz"
+  resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
@@ -6235,7 +6235,7 @@ __metadata:
 
 "human-id@npm:^4.1.1":
   version: 4.2.0
-  resolution: "human-id@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhuman-id%2F-%2Fhuman-id-4.2.0.tgz"
+  resolution: "human-id@npm:4.2.0"
   bin:
     human-id: dist/cli.js
   checksum: 10c0/80071f3b785b2e91080b5f9aa2d079c2e9a464e009ea12c035255b61d1b70beefe7eda42209dff9c1bb9a9fa58e50ada38c1b314ba3a23266a72cd5e9a453e1f
@@ -6244,14 +6244,14 @@ __metadata:
 
 "human-signals@npm:^5.0.0":
   version: 5.0.0
-  resolution: "human-signals@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhuman-signals%2F-%2Fhuman-signals-5.0.0.tgz"
+  resolution: "human-signals@npm:5.0.0"
   checksum: 10c0/5a9359073fe17a8b58e5a085e9a39a950366d9f00217c4ff5878bd312e09d80f460536ea6a3f260b5943a01fe55c158d1cea3fc7bee3d0520aeef04f6d915c82
   languageName: node
   linkType: hard
 
 "husky@npm:^9.1.7":
   version: 9.1.7
-  resolution: "husky@npm:9.1.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhusky%2F-%2Fhusky-9.1.7.tgz"
+  resolution: "husky@npm:9.1.7"
   bin:
     husky: bin.js
   checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
@@ -6260,7 +6260,7 @@ __metadata:
 
 "iconv-lite@npm:^0.4.24, iconv-lite@npm:~0.4.24":
   version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ficonv-lite%2F-%2Ficonv-lite-0.4.24.tgz"
+  resolution: "iconv-lite@npm:0.4.24"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3"
   checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
@@ -6269,7 +6269,7 @@ __metadata:
 
 "iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
-  resolution: "iconv-lite@npm:0.6.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ficonv-lite%2F-%2Ficonv-lite-0.6.3.tgz"
+  resolution: "iconv-lite@npm:0.6.3"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
@@ -6278,7 +6278,7 @@ __metadata:
 
 "iconv-lite@npm:^0.7.0":
   version: 0.7.2
-  resolution: "iconv-lite@npm:0.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ficonv-lite%2F-%2Ficonv-lite-0.7.2.tgz"
+  resolution: "iconv-lite@npm:0.7.2"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
@@ -6287,7 +6287,7 @@ __metadata:
 
 "icss-utils@npm:^5.0.0, icss-utils@npm:^5.1.0":
   version: 5.1.0
-  resolution: "icss-utils@npm:5.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ficss-utils%2F-%2Ficss-utils-5.1.0.tgz"
+  resolution: "icss-utils@npm:5.1.0"
   peerDependencies:
     postcss: ^8.1.0
   checksum: 10c0/39c92936fabd23169c8611d2b5cc39e39d10b19b0d223352f20a7579f75b39d5f786114a6b8fc62bee8c5fed59ba9e0d38f7219a4db383e324fb3061664b043d
@@ -6296,7 +6296,7 @@ __metadata:
 
 "ignore-walk@npm:^7.0.0":
   version: 7.0.0
-  resolution: "ignore-walk@npm:7.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fignore-walk%2F-%2Fignore-walk-7.0.0.tgz"
+  resolution: "ignore-walk@npm:7.0.0"
   dependencies:
     minimatch: "npm:^9.0.0"
   checksum: 10c0/3754bcde369a53a92c1d0835ea93feb6c5b2934984d3f5a8f9dd962d13ac33ee3a9e930901a89b5d46fc061870639d983f497186afdfe3484e135f2ad89f5577
@@ -6305,21 +6305,21 @@ __metadata:
 
 "ignore@npm:^5.2.0":
   version: 5.3.2
-  resolution: "ignore@npm:5.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fignore%2F-%2Fignore-5.3.2.tgz"
+  resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
   languageName: node
   linkType: hard
 
 "ignore@npm:^7.0.3, ignore@npm:^7.0.5":
   version: 7.0.5
-  resolution: "ignore@npm:7.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fignore%2F-%2Fignore-7.0.5.tgz"
+  resolution: "ignore@npm:7.0.5"
   checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
   languageName: node
   linkType: hard
 
 "image-size@npm:~0.5.0":
   version: 0.5.5
-  resolution: "image-size@npm:0.5.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fimage-size%2F-%2Fimage-size-0.5.5.tgz"
+  resolution: "image-size@npm:0.5.5"
   bin:
     image-size: bin/image-size.js
   checksum: 10c0/655204163af06732f483a9fe7cce9dff4a29b7b2e88f5c957a5852e8143fa750f5e54b1955a2ca83de99c5220dbd680002d0d4e09140b01433520f4d5a0b1f4c
@@ -6328,14 +6328,14 @@ __metadata:
 
 "immutable@npm:^5.0.2":
   version: 5.1.4
-  resolution: "immutable@npm:5.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fimmutable%2F-%2Fimmutable-5.1.4.tgz"
+  resolution: "immutable@npm:5.1.4"
   checksum: 10c0/f1c98382e4cde14a0b218be3b9b2f8441888da8df3b8c064aa756071da55fbed6ad696e5959982508456332419be9fdeaf29b2e58d0eadc45483cc16963c0446
   languageName: node
   linkType: hard
 
 "import-fresh@npm:^3.3.0":
   version: 3.3.1
-  resolution: "import-fresh@npm:3.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fimport-fresh%2F-%2Fimport-fresh-3.3.1.tgz"
+  resolution: "import-fresh@npm:3.3.1"
   dependencies:
     parent-module: "npm:^1.0.0"
     resolve-from: "npm:^4.0.0"
@@ -6345,7 +6345,7 @@ __metadata:
 
 "import-local@npm:^3.2.0":
   version: 3.2.0
-  resolution: "import-local@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fimport-local%2F-%2Fimport-local-3.2.0.tgz"
+  resolution: "import-local@npm:3.2.0"
   dependencies:
     pkg-dir: "npm:^4.2.0"
     resolve-cwd: "npm:^3.0.0"
@@ -6357,28 +6357,28 @@ __metadata:
 
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
-  resolution: "imurmurhash@npm:0.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fimurmurhash%2F-%2Fimurmurhash-0.1.4.tgz"
+  resolution: "imurmurhash@npm:0.1.4"
   checksum: 10c0/8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
   languageName: node
   linkType: hard
 
 "indent-string@npm:^3.0.0":
   version: 3.2.0
-  resolution: "indent-string@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Findent-string%2F-%2Findent-string-3.2.0.tgz"
+  resolution: "indent-string@npm:3.2.0"
   checksum: 10c0/91b6d61621d24944c5c4d365d6f1ff4a490264ccaf1162a602faa0d323e69231db2180ad4ccc092c2f49cf8888cdb3da7b73e904cc0fdeec40d0bfb41ceb9478
   languageName: node
   linkType: hard
 
 "index-to-position@npm:^1.1.0":
   version: 1.2.0
-  resolution: "index-to-position@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Findex-to-position%2F-%2Findex-to-position-1.2.0.tgz"
+  resolution: "index-to-position@npm:1.2.0"
   checksum: 10c0/d7ac9fae9fad1d7fbeb7bd92e1553b26e8b10522c2d80af5c362828428a41360e21fc5915d7b8c8227eb0f0d37b12099846ac77381a04d6c0059eb81749e374d
   languageName: node
   linkType: hard
 
 "inflight@npm:^1.0.4":
   version: 1.0.6
-  resolution: "inflight@npm:1.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Finflight%2F-%2Finflight-1.0.6.tgz"
+  resolution: "inflight@npm:1.0.6"
   dependencies:
     once: "npm:^1.3.0"
     wrappy: "npm:1"
@@ -6388,28 +6388,28 @@ __metadata:
 
 "inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
-  resolution: "inherits@npm:2.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Finherits%2F-%2Finherits-2.0.4.tgz"
+  resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
 "ini@npm:4.1.1":
   version: 4.1.1
-  resolution: "ini@npm:4.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fini%2F-%2Fini-4.1.1.tgz"
+  resolution: "ini@npm:4.1.1"
   checksum: 10c0/7fddc8dfd3e63567d4fdd5d999d1bf8a8487f1479d0b34a1d01f28d391a9228d261e19abc38e1a6a1ceb3400c727204fce05725d5eb598dfcf2077a1e3afe211
   languageName: node
   linkType: hard
 
 "ini@npm:^1.3.4, ini@npm:~1.3.0":
   version: 1.3.8
-  resolution: "ini@npm:1.3.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fini%2F-%2Fini-1.3.8.tgz"
+  resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
   languageName: node
   linkType: hard
 
 "inquirer-autosubmit-prompt@npm:^0.2.0":
   version: 0.2.0
-  resolution: "inquirer-autosubmit-prompt@npm:0.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Finquirer-autosubmit-prompt%2F-%2Finquirer-autosubmit-prompt-0.2.0.tgz"
+  resolution: "inquirer-autosubmit-prompt@npm:0.2.0"
   dependencies:
     chalk: "npm:^2.4.1"
     inquirer: "npm:^6.2.1"
@@ -6420,7 +6420,7 @@ __metadata:
 
 "inquirer@npm:^12.3.2":
   version: 12.11.1
-  resolution: "inquirer@npm:12.11.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Finquirer%2F-%2Finquirer-12.11.1.tgz"
+  resolution: "inquirer@npm:12.11.1"
   dependencies:
     "@inquirer/ansi": "npm:^1.0.2"
     "@inquirer/core": "npm:^10.3.2"
@@ -6440,7 +6440,7 @@ __metadata:
 
 "inquirer@npm:^6.2.1":
   version: 6.5.2
-  resolution: "inquirer@npm:6.5.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Finquirer%2F-%2Finquirer-6.5.2.tgz"
+  resolution: "inquirer@npm:6.5.2"
   dependencies:
     ansi-escapes: "npm:^3.2.0"
     chalk: "npm:^2.4.2"
@@ -6461,7 +6461,7 @@ __metadata:
 
 "inquirer@npm:^7.0.0":
   version: 7.3.3
-  resolution: "inquirer@npm:7.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Finquirer%2F-%2Finquirer-7.3.3.tgz"
+  resolution: "inquirer@npm:7.3.3"
   dependencies:
     ansi-escapes: "npm:^4.2.1"
     chalk: "npm:^4.1.0"
@@ -6482,7 +6482,7 @@ __metadata:
 
 "ioredis@npm:^5.3.2":
   version: 5.10.0
-  resolution: "ioredis@npm:5.10.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fioredis%2F-%2Fioredis-5.10.0.tgz"
+  resolution: "ioredis@npm:5.10.0"
   dependencies:
     "@ioredis/commands": "npm:1.5.1"
     cluster-key-slot: "npm:^1.1.0"
@@ -6499,28 +6499,28 @@ __metadata:
 
 "ip-address@npm:^10.0.1":
   version: 10.1.0
-  resolution: "ip-address@npm:10.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fip-address%2F-%2Fip-address-10.1.0.tgz"
+  resolution: "ip-address@npm:10.1.0"
   checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
   languageName: node
   linkType: hard
 
 "ipaddr.js@npm:1.9.1":
   version: 1.9.1
-  resolution: "ipaddr.js@npm:1.9.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fipaddr.js%2F-%2Fipaddr.js-1.9.1.tgz"
+  resolution: "ipaddr.js@npm:1.9.1"
   checksum: 10c0/0486e775047971d3fdb5fb4f063829bac45af299ae0b82dcf3afa2145338e08290563a2a70f34b732d795ecc8311902e541a8530eeb30d75860a78ff4e94ce2a
   languageName: node
   linkType: hard
 
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
-  resolution: "is-arrayish@npm:0.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-arrayish%2F-%2Fis-arrayish-0.2.1.tgz"
+  resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
   languageName: node
   linkType: hard
 
 "is-binary-path@npm:~2.1.0":
   version: 2.1.0
-  resolution: "is-binary-path@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-binary-path%2F-%2Fis-binary-path-2.1.0.tgz"
+  resolution: "is-binary-path@npm:2.1.0"
   dependencies:
     binary-extensions: "npm:^2.0.0"
   checksum: 10c0/a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
@@ -6529,7 +6529,7 @@ __metadata:
 
 "is-core-module@npm:^2.16.1":
   version: 2.16.1
-  resolution: "is-core-module@npm:2.16.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-core-module%2F-%2Fis-core-module-2.16.1.tgz"
+  resolution: "is-core-module@npm:2.16.1"
   dependencies:
     hasown: "npm:^2.0.2"
   checksum: 10c0/898443c14780a577e807618aaae2b6f745c8538eca5c7bc11388a3f2dc6de82b9902bcc7eb74f07be672b11bbe82dd6a6edded44a00cb3d8f933d0459905eedd
@@ -6538,7 +6538,7 @@ __metadata:
 
 "is-docker@npm:^3.0.0":
   version: 3.0.0
-  resolution: "is-docker@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-docker%2F-%2Fis-docker-3.0.0.tgz"
+  resolution: "is-docker@npm:3.0.0"
   bin:
     is-docker: cli.js
   checksum: 10c0/d2c4f8e6d3e34df75a5defd44991b6068afad4835bb783b902fa12d13ebdb8f41b2a199dcb0b5ed2cb78bfee9e4c0bbdb69c2d9646f4106464674d3e697a5856
@@ -6547,7 +6547,7 @@ __metadata:
 
 "is-expression@npm:^4.0.0":
   version: 4.0.0
-  resolution: "is-expression@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-expression%2F-%2Fis-expression-4.0.0.tgz"
+  resolution: "is-expression@npm:4.0.0"
   dependencies:
     acorn: "npm:^7.1.1"
     object-assign: "npm:^4.1.1"
@@ -6557,14 +6557,14 @@ __metadata:
 
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
-  resolution: "is-extglob@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-extglob%2F-%2Fis-extglob-2.1.1.tgz"
+  resolution: "is-extglob@npm:2.1.1"
   checksum: 10c0/5487da35691fbc339700bbb2730430b07777a3c21b9ebaecb3072512dfd7b4ba78ac2381a87e8d78d20ea08affb3f1971b4af629173a6bf435ff8a4c47747912
   languageName: node
   linkType: hard
 
 "is-fullwidth-code-point@npm:^1.0.0":
   version: 1.0.0
-  resolution: "is-fullwidth-code-point@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-fullwidth-code-point%2F-%2Fis-fullwidth-code-point-1.0.0.tgz"
+  resolution: "is-fullwidth-code-point@npm:1.0.0"
   dependencies:
     number-is-nan: "npm:^1.0.0"
   checksum: 10c0/12acfcf16142f2d431bf6af25d68569d3198e81b9799b4ae41058247aafcc666b0127d64384ea28e67a746372611fcbe9b802f69175287aba466da3eddd5ba0f
@@ -6573,21 +6573,21 @@ __metadata:
 
 "is-fullwidth-code-point@npm:^2.0.0":
   version: 2.0.0
-  resolution: "is-fullwidth-code-point@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-fullwidth-code-point%2F-%2Fis-fullwidth-code-point-2.0.0.tgz"
+  resolution: "is-fullwidth-code-point@npm:2.0.0"
   checksum: 10c0/e58f3e4a601fc0500d8b2677e26e9fe0cd450980e66adb29d85b6addf7969731e38f8e43ed2ec868a09c101a55ac3d8b78902209269f38c5286bc98f5bc1b4d9
   languageName: node
   linkType: hard
 
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
-  resolution: "is-fullwidth-code-point@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-fullwidth-code-point%2F-%2Fis-fullwidth-code-point-3.0.0.tgz"
+  resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
   languageName: node
   linkType: hard
 
 "is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
-  resolution: "is-glob@npm:4.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-glob%2F-%2Fis-glob-4.0.3.tgz"
+  resolution: "is-glob@npm:4.0.3"
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
@@ -6596,7 +6596,7 @@ __metadata:
 
 "is-in-ci@npm:^1.0.0":
   version: 1.0.0
-  resolution: "is-in-ci@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-in-ci%2F-%2Fis-in-ci-1.0.0.tgz"
+  resolution: "is-in-ci@npm:1.0.0"
   bin:
     is-in-ci: cli.js
   checksum: 10c0/98f9cec4c35aece4cf731abf35ebf28359a9b0324fac810da05b842515d9ccb33b8999c1d9a679f0362e1a4df3292065c38d7f86327b1387fa667bc0150f4898
@@ -6605,7 +6605,7 @@ __metadata:
 
 "is-inside-container@npm:^1.0.0":
   version: 1.0.0
-  resolution: "is-inside-container@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-inside-container%2F-%2Fis-inside-container-1.0.0.tgz"
+  resolution: "is-inside-container@npm:1.0.0"
   dependencies:
     is-docker: "npm:^3.0.0"
   bin:
@@ -6616,7 +6616,7 @@ __metadata:
 
 "is-installed-globally@npm:^1.0.0":
   version: 1.0.0
-  resolution: "is-installed-globally@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-installed-globally%2F-%2Fis-installed-globally-1.0.0.tgz"
+  resolution: "is-installed-globally@npm:1.0.0"
   dependencies:
     global-directory: "npm:^4.0.1"
     is-path-inside: "npm:^4.0.0"
@@ -6626,28 +6626,28 @@ __metadata:
 
 "is-interactive@npm:^2.0.0":
   version: 2.0.0
-  resolution: "is-interactive@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-interactive%2F-%2Fis-interactive-2.0.0.tgz"
+  resolution: "is-interactive@npm:2.0.0"
   checksum: 10c0/801c8f6064f85199dc6bf99b5dd98db3282e930c3bc197b32f2c5b89313bb578a07d1b8a01365c4348c2927229234f3681eb861b9c2c92bee72ff397390fa600
   languageName: node
   linkType: hard
 
 "is-npm@npm:^6.0.0":
   version: 6.1.0
-  resolution: "is-npm@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-npm%2F-%2Fis-npm-6.1.0.tgz"
+  resolution: "is-npm@npm:6.1.0"
   checksum: 10c0/2319580963e7b77f51b07d242064926894472e0b8aab7d4f67aa58a2032715a18c77844a2d963718b8ee1eac112ce4dbcd55a9d994f589d5994d46b57b5cdfda
   languageName: node
   linkType: hard
 
 "is-number@npm:^7.0.0":
   version: 7.0.0
-  resolution: "is-number@npm:7.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-number%2F-%2Fis-number-7.0.0.tgz"
+  resolution: "is-number@npm:7.0.0"
   checksum: 10c0/b4686d0d3053146095ccd45346461bc8e53b80aeb7671cc52a4de02dbbf7dc0d1d2a986e2fe4ae206984b4d34ef37e8b795ebc4f4295c978373e6575e295d811
   languageName: node
   linkType: hard
 
 "is-observable@npm:^1.1.0":
   version: 1.1.0
-  resolution: "is-observable@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-observable%2F-%2Fis-observable-1.1.0.tgz"
+  resolution: "is-observable@npm:1.1.0"
   dependencies:
     symbol-observable: "npm:^1.1.0"
   checksum: 10c0/cf3166b0822f70ad06e7851e09430166ce658349d54aaa64c93a03320420b9285735821b23164bdce741ff83a86730ac3e53035ce4e2511ed843dbff4105bfa2
@@ -6656,28 +6656,28 @@ __metadata:
 
 "is-path-cwd@npm:^3.0.0":
   version: 3.0.0
-  resolution: "is-path-cwd@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-path-cwd%2F-%2Fis-path-cwd-3.0.0.tgz"
+  resolution: "is-path-cwd@npm:3.0.0"
   checksum: 10c0/8135b789c74e137501ca33b11a846c32d160c517037c0ce390004a98335e010b9712792d97c73d9e98a5ecbcfd03589a81e95c72e1c05014a69fead963a02753
   languageName: node
   linkType: hard
 
 "is-path-inside@npm:^4.0.0":
   version: 4.0.0
-  resolution: "is-path-inside@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-path-inside%2F-%2Fis-path-inside-4.0.0.tgz"
+  resolution: "is-path-inside@npm:4.0.0"
   checksum: 10c0/51188d7e2b1d907a9a5f7c18d99a90b60870b951ed87cf97595d9aaa429d4c010652c3350bcbf31182e7f4b0eab9a1860b43e16729b13cb1a44baaa6cdb64c46
   languageName: node
   linkType: hard
 
 "is-promise@npm:^2.0.0, is-promise@npm:^2.1.0":
   version: 2.2.2
-  resolution: "is-promise@npm:2.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-promise%2F-%2Fis-promise-2.2.2.tgz"
+  resolution: "is-promise@npm:2.2.2"
   checksum: 10c0/2dba959812380e45b3df0fb12e7cb4d4528c989c7abb03ececb1d1fd6ab1cbfee956ca9daa587b9db1d8ac3c1e5738cf217bdb3dfd99df8c691be4c00ae09069
   languageName: node
   linkType: hard
 
 "is-reference@npm:^3.0.0, is-reference@npm:^3.0.1":
   version: 3.0.3
-  resolution: "is-reference@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-reference%2F-%2Fis-reference-3.0.3.tgz"
+  resolution: "is-reference@npm:3.0.3"
   dependencies:
     "@types/estree": "npm:^1.0.6"
   checksum: 10c0/35edd284cfb4cd9e9f08973f20e276ec517eaca31f5f049598e97dbb2d05544973dde212dac30fddee5b420930bff365e2e67dcd1293d0866c6720377382e3e5
@@ -6686,7 +6686,7 @@ __metadata:
 
 "is-regex@npm:^1.0.3":
   version: 1.2.1
-  resolution: "is-regex@npm:1.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-regex%2F-%2Fis-regex-1.2.1.tgz"
+  resolution: "is-regex@npm:1.2.1"
   dependencies:
     call-bound: "npm:^1.0.2"
     gopd: "npm:^1.2.0"
@@ -6698,7 +6698,7 @@ __metadata:
 
 "is-scoped@npm:^3.0.0":
   version: 3.0.0
-  resolution: "is-scoped@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-scoped%2F-%2Fis-scoped-3.0.0.tgz"
+  resolution: "is-scoped@npm:3.0.0"
   dependencies:
     scoped-regex: "npm:^3.0.0"
   checksum: 10c0/9061cb11ea6e41e215810181dad2475df8172328f9e6ac2f0a79cfaeeee605ca025e3b18fb910bf4c277f4e61fe912660e687b16d2f9446d52cf487c4fad89a9
@@ -6707,28 +6707,28 @@ __metadata:
 
 "is-stream@npm:^1.1.0":
   version: 1.1.0
-  resolution: "is-stream@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-stream%2F-%2Fis-stream-1.1.0.tgz"
+  resolution: "is-stream@npm:1.1.0"
   checksum: 10c0/b8ae7971e78d2e8488d15f804229c6eed7ed36a28f8807a1815938771f4adff0e705218b7dab968270433f67103e4fef98062a0beea55d64835f705ee72c7002
   languageName: node
   linkType: hard
 
 "is-stream@npm:^2.0.0":
   version: 2.0.1
-  resolution: "is-stream@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-stream%2F-%2Fis-stream-2.0.1.tgz"
+  resolution: "is-stream@npm:2.0.1"
   checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
   languageName: node
   linkType: hard
 
 "is-stream@npm:^3.0.0":
   version: 3.0.0
-  resolution: "is-stream@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-stream%2F-%2Fis-stream-3.0.0.tgz"
+  resolution: "is-stream@npm:3.0.0"
   checksum: 10c0/eb2f7127af02ee9aa2a0237b730e47ac2de0d4e76a4a905a50a11557f2339df5765eaea4ceb8029f1efa978586abe776908720bfcb1900c20c6ec5145f6f29d8
   languageName: node
   linkType: hard
 
 "is-string-and-not-blank@npm:^0.0.2":
   version: 0.0.2
-  resolution: "is-string-and-not-blank@npm:0.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-string-and-not-blank%2F-%2Fis-string-and-not-blank-0.0.2.tgz"
+  resolution: "is-string-and-not-blank@npm:0.0.2"
   dependencies:
     is-string-blank: "npm:^1.0.1"
   checksum: 10c0/07beb0931bb7c815d5d05ca950b4406bec9fc7095e134fa212265da927296606f25b81fc2418f972c079b19e75c68289b238445e019f2a9fb25b76d691a410e7
@@ -6737,14 +6737,14 @@ __metadata:
 
 "is-string-blank@npm:^1.0.1":
   version: 1.0.1
-  resolution: "is-string-blank@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-string-blank%2F-%2Fis-string-blank-1.0.1.tgz"
+  resolution: "is-string-blank@npm:1.0.1"
   checksum: 10c0/2e664a061fb9354f6eccffdd7d662051d19ce951f59ae25392b871f796e06dc82659fb68560b267ccc81b700c1078c0fb8e31959955d759c2f3713015ccfb60f
   languageName: node
   linkType: hard
 
 "is-subdir@npm:^1.1.1":
   version: 1.2.0
-  resolution: "is-subdir@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-subdir%2F-%2Fis-subdir-1.2.0.tgz"
+  resolution: "is-subdir@npm:1.2.0"
   dependencies:
     better-path-resolve: "npm:1.0.0"
   checksum: 10c0/03a03ee2ee6578ce589b1cfaf00e65c86b20fd1b82c1660625557c535439a7477cda77e20c62cda6d4c99e7fd908b4619355ae2d989f4a524a35350a44353032
@@ -6753,21 +6753,21 @@ __metadata:
 
 "is-unicode-supported@npm:^2.0.0":
   version: 2.1.0
-  resolution: "is-unicode-supported@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-unicode-supported%2F-%2Fis-unicode-supported-2.1.0.tgz"
+  resolution: "is-unicode-supported@npm:2.1.0"
   checksum: 10c0/a0f53e9a7c1fdbcf2d2ef6e40d4736fdffff1c9f8944c75e15425118ff3610172c87bf7bc6c34d3903b04be59790bb2212ddbe21ee65b5a97030fc50370545a5
   languageName: node
   linkType: hard
 
 "is-url-superb@npm:^6.1.0":
   version: 6.1.0
-  resolution: "is-url-superb@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-url-superb%2F-%2Fis-url-superb-6.1.0.tgz"
+  resolution: "is-url-superb@npm:6.1.0"
   checksum: 10c0/f22c5e49503cb616a0fbab9a4eddf57718213d268355c151ba06e65a8f677c724a9c25e698dbee3cf94dd2686c8c84803317a1e68e3724ad48f390f7cd966b7d
   languageName: node
   linkType: hard
 
 "is-valid-npm-name@npm:^0.0.5":
   version: 0.0.5
-  resolution: "is-valid-npm-name@npm:0.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-valid-npm-name%2F-%2Fis-valid-npm-name-0.0.5.tgz"
+  resolution: "is-valid-npm-name@npm:0.0.5"
   dependencies:
     is-string-and-not-blank: "npm:^0.0.2"
     speakingurl: "npm:^14.0.1"
@@ -6777,21 +6777,21 @@ __metadata:
 
 "is-what@npm:^3.14.1":
   version: 3.14.1
-  resolution: "is-what@npm:3.14.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-what%2F-%2Fis-what-3.14.1.tgz"
+  resolution: "is-what@npm:3.14.1"
   checksum: 10c0/4b770b85454c877b6929a84fd47c318e1f8c2ff70fd72fd625bc3fde8e0c18a6e57345b6e7aa1ee9fbd1c608d27cfe885df473036c5c2e40cd2187250804a2c7
   languageName: node
   linkType: hard
 
 "is-windows@npm:^1.0.0":
   version: 1.0.2
-  resolution: "is-windows@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-windows%2F-%2Fis-windows-1.0.2.tgz"
+  resolution: "is-windows@npm:1.0.2"
   checksum: 10c0/b32f418ab3385604a66f1b7a3ce39d25e8881dee0bd30816dc8344ef6ff9df473a732bcc1ec4e84fe99b2f229ae474f7133e8e93f9241686cfcf7eebe53ba7a5
   languageName: node
   linkType: hard
 
 "is-wsl@npm:^3.1.0":
   version: 3.1.0
-  resolution: "is-wsl@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-wsl%2F-%2Fis-wsl-3.1.0.tgz"
+  resolution: "is-wsl@npm:3.1.0"
   dependencies:
     is-inside-container: "npm:^1.0.0"
   checksum: 10c0/d3317c11995690a32c362100225e22ba793678fe8732660c6de511ae71a0ff05b06980cf21f98a6bf40d7be0e9e9506f859abe00a1118287d63e53d0a3d06947
@@ -6800,35 +6800,35 @@ __metadata:
 
 "isexe@npm:^2.0.0":
   version: 2.0.0
-  resolution: "isexe@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fisexe%2F-%2Fisexe-2.0.0.tgz"
+  resolution: "isexe@npm:2.0.0"
   checksum: 10c0/228cfa503fadc2c31596ab06ed6aa82c9976eec2bfd83397e7eaf06d0ccf42cd1dfd6743bf9aeb01aebd4156d009994c5f76ea898d2832c1fe342da923ca457d
   languageName: node
   linkType: hard
 
 "isexe@npm:^3.1.1":
   version: 3.1.1
-  resolution: "isexe@npm:3.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fisexe%2F-%2Fisexe-3.1.1.tgz"
+  resolution: "isexe@npm:3.1.1"
   checksum: 10c0/9ec257654093443eb0a528a9c8cbba9c0ca7616ccb40abd6dde7202734d96bb86e4ac0d764f0f8cd965856aacbff2f4ce23e730dc19dfb41e3b0d865ca6fdcc7
   languageName: node
   linkType: hard
 
 "issue-regex@npm:^4.3.0":
   version: 4.3.0
-  resolution: "issue-regex@npm:4.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fissue-regex%2F-%2Fissue-regex-4.3.0.tgz"
+  resolution: "issue-regex@npm:4.3.0"
   checksum: 10c0/4a8b14f93a0e190c896714b56eda1b3047fb6c64b39f61ace922cc1bc9758a2b46f5e4fa8d04679e8c90662d7cbc18a6778e3f0a23b2b0ee88826816cd4724f7
   languageName: node
   linkType: hard
 
 "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
   version: 3.2.2
-  resolution: "istanbul-lib-coverage@npm:3.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fistanbul-lib-coverage%2F-%2Fistanbul-lib-coverage-3.2.2.tgz"
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
   checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
   languageName: node
   linkType: hard
 
 "istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
   version: 3.0.1
-  resolution: "istanbul-lib-report@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fistanbul-lib-report%2F-%2Fistanbul-lib-report-3.0.1.tgz"
+  resolution: "istanbul-lib-report@npm:3.0.1"
   dependencies:
     istanbul-lib-coverage: "npm:^3.0.0"
     make-dir: "npm:^4.0.0"
@@ -6839,7 +6839,7 @@ __metadata:
 
 "istanbul-reports@npm:^3.2.0":
   version: 3.2.0
-  resolution: "istanbul-reports@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fistanbul-reports%2F-%2Fistanbul-reports-3.2.0.tgz"
+  resolution: "istanbul-reports@npm:3.2.0"
   dependencies:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
@@ -6849,7 +6849,7 @@ __metadata:
 
 "jiti@npm:^2.5.1":
   version: 2.6.1
-  resolution: "jiti@npm:2.6.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjiti%2F-%2Fjiti-2.6.1.tgz"
+  resolution: "jiti@npm:2.6.1"
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10c0/79b2e96a8e623f66c1b703b98ec1b8be4500e1d217e09b09e343471bbb9c105381b83edbb979d01cef18318cc45ce6e153571b6c83122170eefa531c64b6789b
@@ -6858,35 +6858,35 @@ __metadata:
 
 "jose@npm:^4.15.4":
   version: 4.15.9
-  resolution: "jose@npm:4.15.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjose%2F-%2Fjose-4.15.9.tgz"
+  resolution: "jose@npm:4.15.9"
   checksum: 10c0/4ed4ddf4a029db04bd167f2215f65d7245e4dc5f36d7ac3c0126aab38d66309a9e692f52df88975d99429e357e5fd8bab340ff20baab544d17684dd1d940a0f4
   languageName: node
   linkType: hard
 
 "js-stringify@npm:^1.0.2":
   version: 1.0.2
-  resolution: "js-stringify@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-stringify%2F-%2Fjs-stringify-1.0.2.tgz"
+  resolution: "js-stringify@npm:1.0.2"
   checksum: 10c0/a450c04fde3a7e1c27f1c3c4300433f8d79322f9e3c2e76266843cef8c0b5a69b5f11b5f173212b2f15f2df09e068ef7ddf46ef775e2486f3006a6f4e912578d
   languageName: node
   linkType: hard
 
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
-  resolution: "js-tokens@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-tokens%2F-%2Fjs-tokens-4.0.0.tgz"
+  resolution: "js-tokens@npm:4.0.0"
   checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
   languageName: node
   linkType: hard
 
 "js-tokens@npm:^9.0.1":
   version: 9.0.1
-  resolution: "js-tokens@npm:9.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-tokens%2F-%2Fjs-tokens-9.0.1.tgz"
+  resolution: "js-tokens@npm:9.0.1"
   checksum: 10c0/68dcab8f233dde211a6b5fd98079783cbcd04b53617c1250e3553ee16ab3e6134f5e65478e41d82f6d351a052a63d71024553933808570f04dbf828d7921e80e
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^3.6.1":
   version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-yaml%2F-%2Fjs-yaml-3.15.0.tgz"
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
@@ -6898,7 +6898,7 @@ __metadata:
 
 "js-yaml@npm:^4.1.0":
   version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-yaml%2F-%2Fjs-yaml-4.1.1.tgz"
+  resolution: "js-yaml@npm:4.1.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
@@ -6909,7 +6909,7 @@ __metadata:
 
 "js-yaml@npm:^4.1.1":
   version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-yaml%2F-%2Fjs-yaml-4.3.0.tgz"
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
@@ -6920,7 +6920,7 @@ __metadata:
 
 "jsesc@npm:^3.0.2":
   version: 3.1.0
-  resolution: "jsesc@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjsesc%2F-%2Fjsesc-3.1.0.tgz"
+  resolution: "jsesc@npm:3.1.0"
   bin:
     jsesc: bin/jsesc
   checksum: 10c0/531779df5ec94f47e462da26b4cbf05eb88a83d9f08aac2ba04206508fc598527a153d08bd462bae82fc78b3eaa1a908e1a4a79f886e9238641c4cdefaf118b1
@@ -6929,7 +6929,7 @@ __metadata:
 
 "json-bigint@npm:^1.0.0":
   version: 1.0.0
-  resolution: "json-bigint@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjson-bigint%2F-%2Fjson-bigint-1.0.0.tgz"
+  resolution: "json-bigint@npm:1.0.0"
   dependencies:
     bignumber.js: "npm:^9.0.0"
   checksum: 10c0/e3f34e43be3284b573ea150a3890c92f06d54d8ded72894556357946aeed9877fd795f62f37fe16509af189fd314ab1104d0fd0f163746ad231b9f378f5b33f4
@@ -6938,21 +6938,21 @@ __metadata:
 
 "json-parse-even-better-errors@npm:^2.3.0":
   version: 2.3.1
-  resolution: "json-parse-even-better-errors@npm:2.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjson-parse-even-better-errors%2F-%2Fjson-parse-even-better-errors-2.3.1.tgz"
+  resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 10c0/140932564c8f0b88455432e0f33c4cb4086b8868e37524e07e723f4eaedb9425bdc2bafd71bd1d9765bd15fd1e2d126972bc83990f55c467168c228c24d665f3
   languageName: node
   linkType: hard
 
 "json-stream-stringify@npm:3.0.1":
   version: 3.0.1
-  resolution: "json-stream-stringify@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjson-stream-stringify%2F-%2Fjson-stream-stringify-3.0.1.tgz"
+  resolution: "json-stream-stringify@npm:3.0.1"
   checksum: 10c0/42413fc8ddab5ad0a1fe4eda47609a1e1f898c7d6be32ebc3df92741cbe1bae65b79dfb1efb7bfe5d1c85f779def218e02286e733044e9a52def4d64e2a080bd
   languageName: node
   linkType: hard
 
 "json5@npm:^2.1.2, json5@npm:^2.2.3":
   version: 2.2.3
-  resolution: "json5@npm:2.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjson5%2F-%2Fjson5-2.2.3.tgz"
+  resolution: "json5@npm:2.2.3"
   bin:
     json5: lib/cli.js
   checksum: 10c0/5a04eed94810fa55c5ea138b2f7a5c12b97c3750bc63d11e511dcecbfef758003861522a070c2272764ee0f4e3e323862f386945aeb5b85b87ee43f084ba586c
@@ -6961,7 +6961,7 @@ __metadata:
 
 "jsonfile@npm:^4.0.0":
   version: 4.0.0
-  resolution: "jsonfile@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjsonfile%2F-%2Fjsonfile-4.0.0.tgz"
+  resolution: "jsonfile@npm:4.0.0"
   dependencies:
     graceful-fs: "npm:^4.1.6"
   dependenciesMeta:
@@ -6973,7 +6973,7 @@ __metadata:
 
 "jsonfile@npm:^6.0.1":
   version: 6.2.0
-  resolution: "jsonfile@npm:6.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjsonfile%2F-%2Fjsonfile-6.2.0.tgz"
+  resolution: "jsonfile@npm:6.2.0"
   dependencies:
     graceful-fs: "npm:^4.1.6"
     universalify: "npm:^2.0.0"
@@ -6986,7 +6986,7 @@ __metadata:
 
 "jsonwebtoken@npm:^9.0.0":
   version: 9.0.3
-  resolution: "jsonwebtoken@npm:9.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjsonwebtoken%2F-%2Fjsonwebtoken-9.0.3.tgz"
+  resolution: "jsonwebtoken@npm:9.0.3"
   dependencies:
     jws: "npm:^4.0.1"
     lodash.includes: "npm:^4.3.0"
@@ -7004,7 +7004,7 @@ __metadata:
 
 "jstransformer@npm:1.0.0":
   version: 1.0.0
-  resolution: "jstransformer@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjstransformer%2F-%2Fjstransformer-1.0.0.tgz"
+  resolution: "jstransformer@npm:1.0.0"
   dependencies:
     is-promise: "npm:^2.0.0"
     promise: "npm:^7.0.1"
@@ -7014,7 +7014,7 @@ __metadata:
 
 "jwa@npm:^2.0.1":
   version: 2.0.1
-  resolution: "jwa@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjwa%2F-%2Fjwa-2.0.1.tgz"
+  resolution: "jwa@npm:2.0.1"
   dependencies:
     buffer-equal-constant-time: "npm:^1.0.1"
     ecdsa-sig-formatter: "npm:1.0.11"
@@ -7025,7 +7025,7 @@ __metadata:
 
 "jwks-rsa@npm:^3.1.0":
   version: 3.2.1
-  resolution: "jwks-rsa@npm:3.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjwks-rsa%2F-%2Fjwks-rsa-3.2.1.tgz"
+  resolution: "jwks-rsa@npm:3.2.1"
   dependencies:
     "@types/jsonwebtoken": "npm:^9.0.4"
     debug: "npm:^4.3.4"
@@ -7038,7 +7038,7 @@ __metadata:
 
 "jws@npm:^4.0.0, jws@npm:^4.0.1":
   version: 4.0.1
-  resolution: "jws@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjws%2F-%2Fjws-4.0.1.tgz"
+  resolution: "jws@npm:4.0.1"
   dependencies:
     jwa: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
@@ -7048,14 +7048,14 @@ __metadata:
 
 "ky@npm:^1.2.0":
   version: 1.14.2
-  resolution: "ky@npm:1.14.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fky%2F-%2Fky-1.14.2.tgz"
+  resolution: "ky@npm:1.14.2"
   checksum: 10c0/ea5f08660ec8574ad6b116338059d1f2bac42ee917d56df268758405edfb3d17d5baa78913ee289eb6de976f648b1ff7798d5f8a7732c61e85e59d8f10f16795
   languageName: node
   linkType: hard
 
 "latest-version@npm:^9.0.0":
   version: 9.0.0
-  resolution: "latest-version@npm:9.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flatest-version%2F-%2Flatest-version-9.0.0.tgz"
+  resolution: "latest-version@npm:9.0.0"
   dependencies:
     package-json: "npm:^10.0.0"
   checksum: 10c0/643cfda3a58dfb3af221a2950e433393d28a5adbe225d1cbbb358dbcbb04e9f8dce15b892f8ae3e3156f50693428dbd7ca13a69edfbdfcd94e62519480d7041e
@@ -7064,7 +7064,7 @@ __metadata:
 
 "less-loader@npm:^12.2.0":
   version: 12.3.0
-  resolution: "less-loader@npm:12.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fless-loader%2F-%2Fless-loader-12.3.0.tgz"
+  resolution: "less-loader@npm:12.3.0"
   peerDependencies:
     "@rspack/core": 0.x || 1.x
     less: ^3.5.0 || ^4.0.0
@@ -7080,7 +7080,7 @@ __metadata:
 
 "less@npm:^4.4.2":
   version: 4.5.1
-  resolution: "less@npm:4.5.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fless%2F-%2Fless-4.5.1.tgz"
+  resolution: "less@npm:4.5.1"
   dependencies:
     copy-anything: "npm:^2.0.1"
     errno: "npm:^0.1.1"
@@ -7115,28 +7115,28 @@ __metadata:
 
 "limiter@npm:^1.1.5":
   version: 1.1.5
-  resolution: "limiter@npm:1.1.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flimiter%2F-%2Flimiter-1.1.5.tgz"
+  resolution: "limiter@npm:1.1.5"
   checksum: 10c0/ebe2b20a820d1f67b8e1724051246434c419b2da041a7e9cd943f6daf113b8d17a52a1bd88fb79be5b624c10283ecb737f50edb5c1c88c71f4cd367108c97300
   languageName: node
   linkType: hard
 
 "lines-and-columns@npm:2.0.4":
   version: 2.0.4
-  resolution: "lines-and-columns@npm:2.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flines-and-columns%2F-%2Flines-and-columns-2.0.4.tgz"
+  resolution: "lines-and-columns@npm:2.0.4"
   checksum: 10c0/4db28bf065cd7ad897c0700f22d3d0d7c5ed6777e138861c601c496d545340df3fc19e18bd04ff8d95a246a245eb55685b82ca2f8c2ca53a008e9c5316250379
   languageName: node
   linkType: hard
 
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
-  resolution: "lines-and-columns@npm:1.2.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flines-and-columns%2F-%2Flines-and-columns-1.2.4.tgz"
+  resolution: "lines-and-columns@npm:1.2.4"
   checksum: 10c0/3da6ee62d4cd9f03f5dc90b4df2540fb85b352081bee77fe4bbcd12c9000ead7f35e0a38b8d09a9bb99b13223446dd8689ff3c4959807620726d788701a83d2d
   languageName: node
   linkType: hard
 
 "listr-input@npm:^0.2.1":
   version: 0.2.1
-  resolution: "listr-input@npm:0.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flistr-input%2F-%2Flistr-input-0.2.1.tgz"
+  resolution: "listr-input@npm:0.2.1"
   dependencies:
     inquirer: "npm:^7.0.0"
     inquirer-autosubmit-prompt: "npm:^0.2.0"
@@ -7148,14 +7148,14 @@ __metadata:
 
 "listr-silent-renderer@npm:^1.1.1":
   version: 1.1.1
-  resolution: "listr-silent-renderer@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flistr-silent-renderer%2F-%2Flistr-silent-renderer-1.1.1.tgz"
+  resolution: "listr-silent-renderer@npm:1.1.1"
   checksum: 10c0/a13e08ebf863516a757bce4887f05290070772113d89095e9f51a07cf0b11a43a7563a67ff3b287c752c08f6d781fdb2123b02957534e3e0675fb564f2a42e1b
   languageName: node
   linkType: hard
 
 "listr-update-renderer@npm:^0.5.0":
   version: 0.5.0
-  resolution: "listr-update-renderer@npm:0.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flistr-update-renderer%2F-%2Flistr-update-renderer-0.5.0.tgz"
+  resolution: "listr-update-renderer@npm:0.5.0"
   dependencies:
     chalk: "npm:^1.1.3"
     cli-truncate: "npm:^0.2.1"
@@ -7173,7 +7173,7 @@ __metadata:
 
 "listr-verbose-renderer@npm:^0.5.0":
   version: 0.5.0
-  resolution: "listr-verbose-renderer@npm:0.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flistr-verbose-renderer%2F-%2Flistr-verbose-renderer-0.5.0.tgz"
+  resolution: "listr-verbose-renderer@npm:0.5.0"
   dependencies:
     chalk: "npm:^2.4.1"
     cli-cursor: "npm:^2.1.0"
@@ -7185,7 +7185,7 @@ __metadata:
 
 "listr@npm:^0.14.3":
   version: 0.14.3
-  resolution: "listr@npm:0.14.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flistr%2F-%2Flistr-0.14.3.tgz"
+  resolution: "listr@npm:0.14.3"
   dependencies:
     "@samverschueren/stream-to-observable": "npm:^0.3.0"
     is-observable: "npm:^1.1.0"
@@ -7202,7 +7202,7 @@ __metadata:
 
 "loader-utils@npm:^2.0.4":
   version: 2.0.4
-  resolution: "loader-utils@npm:2.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Floader-utils%2F-%2Floader-utils-2.0.4.tgz"
+  resolution: "loader-utils@npm:2.0.4"
   dependencies:
     big.js: "npm:^5.2.2"
     emojis-list: "npm:^3.0.0"
@@ -7213,7 +7213,7 @@ __metadata:
 
 "loadware@npm:^2.0.0":
   version: 2.0.0
-  resolution: "loadware@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Floadware%2F-%2Floadware-2.0.0.tgz"
+  resolution: "loadware@npm:2.0.0"
   dependencies:
     app-module-path: "npm:^2.1.0"
   checksum: 10c0/9774b15c547e9c4d4d84447a05eb442947c065b2902e68057373fc38d731d46f039061597d26059af5bb78f2eec7bd8735632d1f46d63ad6db299a908a598bda
@@ -7222,14 +7222,14 @@ __metadata:
 
 "locate-character@npm:^3.0.0":
   version: 3.0.0
-  resolution: "locate-character@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flocate-character%2F-%2Flocate-character-3.0.0.tgz"
+  resolution: "locate-character@npm:3.0.0"
   checksum: 10c0/9da917622395002eb1336fca8cbef1c19904e3dc0b3b8078abe8ff390106d947a86feccecd0346f0e0e19fa017623fb4ccb65263d72a76dfa36e20cc18766b6c
   languageName: node
   linkType: hard
 
 "locate-path@npm:^5.0.0":
   version: 5.0.0
-  resolution: "locate-path@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flocate-path%2F-%2Flocate-path-5.0.0.tgz"
+  resolution: "locate-path@npm:5.0.0"
   dependencies:
     p-locate: "npm:^4.1.0"
   checksum: 10c0/33a1c5247e87e022f9713e6213a744557a3e9ec32c5d0b5efb10aa3a38177615bf90221a5592674857039c1a0fd2063b82f285702d37b792d973e9e72ace6c59
@@ -7238,105 +7238,105 @@ __metadata:
 
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
-  resolution: "lodash.camelcase@npm:4.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.camelcase%2F-%2Flodash.camelcase-4.3.0.tgz"
+  resolution: "lodash.camelcase@npm:4.3.0"
   checksum: 10c0/fcba15d21a458076dd309fce6b1b4bf611d84a0ec252cb92447c948c533ac250b95d2e00955801ebc367e5af5ed288b996d75d37d2035260a937008e14eaf432
   languageName: node
   linkType: hard
 
 "lodash.clonedeep@npm:^4.5.0":
   version: 4.5.0
-  resolution: "lodash.clonedeep@npm:4.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.clonedeep%2F-%2Flodash.clonedeep-4.5.0.tgz"
+  resolution: "lodash.clonedeep@npm:4.5.0"
   checksum: 10c0/2caf0e4808f319d761d2939ee0642fa6867a4bbf2cfce43276698828380756b99d4c4fa226d881655e6ac298dd453fe12a5ec8ba49861777759494c534936985
   languageName: node
   linkType: hard
 
 "lodash.defaults@npm:^4.2.0":
   version: 4.2.0
-  resolution: "lodash.defaults@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.defaults%2F-%2Flodash.defaults-4.2.0.tgz"
+  resolution: "lodash.defaults@npm:4.2.0"
   checksum: 10c0/d5b77aeb702caa69b17be1358faece33a84497bcca814897383c58b28a2f8dfc381b1d9edbec239f8b425126a3bbe4916223da2a576bb0411c2cefd67df80707
   languageName: node
   linkType: hard
 
 "lodash.includes@npm:^4.3.0":
   version: 4.3.0
-  resolution: "lodash.includes@npm:4.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.includes%2F-%2Flodash.includes-4.3.0.tgz"
+  resolution: "lodash.includes@npm:4.3.0"
   checksum: 10c0/7ca498b9b75bf602d04e48c0adb842dfc7d90f77bcb2a91a2b2be34a723ad24bc1c8b3683ec6b2552a90f216c723cdea530ddb11a3320e08fa38265703978f4b
   languageName: node
   linkType: hard
 
 "lodash.isarguments@npm:^3.1.0":
   version: 3.1.0
-  resolution: "lodash.isarguments@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.isarguments%2F-%2Flodash.isarguments-3.1.0.tgz"
+  resolution: "lodash.isarguments@npm:3.1.0"
   checksum: 10c0/5e8f95ba10975900a3920fb039a3f89a5a79359a1b5565e4e5b4310ed6ebe64011e31d402e34f577eca983a1fc01ff86c926e3cbe602e1ddfc858fdd353e62d8
   languageName: node
   linkType: hard
 
 "lodash.isboolean@npm:^3.0.3":
   version: 3.0.3
-  resolution: "lodash.isboolean@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.isboolean%2F-%2Flodash.isboolean-3.0.3.tgz"
+  resolution: "lodash.isboolean@npm:3.0.3"
   checksum: 10c0/0aac604c1ef7e72f9a6b798e5b676606042401dd58e49f051df3cc1e3adb497b3d7695635a5cbec4ae5f66456b951fdabe7d6b387055f13267cde521f10ec7f7
   languageName: node
   linkType: hard
 
 "lodash.isinteger@npm:^4.0.4":
   version: 4.0.4
-  resolution: "lodash.isinteger@npm:4.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.isinteger%2F-%2Flodash.isinteger-4.0.4.tgz"
+  resolution: "lodash.isinteger@npm:4.0.4"
   checksum: 10c0/4c3e023a2373bf65bf366d3b8605b97ec830bca702a926939bcaa53f8e02789b6a176e7f166b082f9365bfec4121bfeb52e86e9040cb8d450e64c858583f61b7
   languageName: node
   linkType: hard
 
 "lodash.isnumber@npm:^3.0.3":
   version: 3.0.3
-  resolution: "lodash.isnumber@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.isnumber%2F-%2Flodash.isnumber-3.0.3.tgz"
+  resolution: "lodash.isnumber@npm:3.0.3"
   checksum: 10c0/2d01530513a1ee4f72dd79528444db4e6360588adcb0e2ff663db2b3f642d4bb3d687051ae1115751ca9082db4fdef675160071226ca6bbf5f0c123dbf0aa12d
   languageName: node
   linkType: hard
 
 "lodash.isplainobject@npm:^4.0.6":
   version: 4.0.6
-  resolution: "lodash.isplainobject@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.isplainobject%2F-%2Flodash.isplainobject-4.0.6.tgz"
+  resolution: "lodash.isplainobject@npm:4.0.6"
   checksum: 10c0/afd70b5c450d1e09f32a737bed06ff85b873ecd3d3d3400458725283e3f2e0bb6bf48e67dbe7a309eb371a822b16a26cca4a63c8c52db3fc7dc9d5f9dd324cbb
   languageName: node
   linkType: hard
 
 "lodash.isstring@npm:^4.0.1":
   version: 4.0.1
-  resolution: "lodash.isstring@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.isstring%2F-%2Flodash.isstring-4.0.1.tgz"
+  resolution: "lodash.isstring@npm:4.0.1"
   checksum: 10c0/09eaf980a283f9eef58ef95b30ec7fee61df4d6bf4aba3b5f096869cc58f24c9da17900febc8ffd67819b4e29de29793190e88dc96983db92d84c95fa85d1c92
   languageName: node
   linkType: hard
 
 "lodash.once@npm:^4.0.0":
   version: 4.1.1
-  resolution: "lodash.once@npm:4.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.once%2F-%2Flodash.once-4.1.1.tgz"
+  resolution: "lodash.once@npm:4.1.1"
   checksum: 10c0/46a9a0a66c45dd812fcc016e46605d85ad599fe87d71a02f6736220554b52ffbe82e79a483ad40f52a8a95755b0d1077fba259da8bfb6694a7abbf4a48f1fc04
   languageName: node
   linkType: hard
 
 "lodash.startcase@npm:^4.4.0":
   version: 4.4.0
-  resolution: "lodash.startcase@npm:4.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.startcase%2F-%2Flodash.startcase-4.4.0.tgz"
+  resolution: "lodash.startcase@npm:4.4.0"
   checksum: 10c0/bd82aa87a45de8080e1c5ee61128c7aee77bf7f1d86f4ff94f4a6d7438fc9e15e5f03374b947be577a93804c8ad6241f0251beaf1452bf716064eeb657b3a9f0
   languageName: node
   linkType: hard
 
 "lodash.zip@npm:^4.2.0":
   version: 4.2.0
-  resolution: "lodash.zip@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.zip%2F-%2Flodash.zip-4.2.0.tgz"
+  resolution: "lodash.zip@npm:4.2.0"
   checksum: 10c0/e596da80a6138e369998b50c78b51ed6cf984b4f239e59056aa18dca5972a213c491c511caf5888a2dec603c67265caf942099bec554a86a5c7ff1937d57f0e4
   languageName: node
   linkType: hard
 
 "lodash@npm:^4.17.12, lodash@npm:^4.17.19, lodash@npm:^4.17.21":
   version: 4.17.21
-  resolution: "lodash@npm:4.17.21::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash%2F-%2Flodash-4.17.21.tgz"
+  resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
   languageName: node
   linkType: hard
 
 "log-symbols@npm:^1.0.2":
   version: 1.0.2
-  resolution: "log-symbols@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flog-symbols%2F-%2Flog-symbols-1.0.2.tgz"
+  resolution: "log-symbols@npm:1.0.2"
   dependencies:
     chalk: "npm:^1.0.0"
   checksum: 10c0/c64e1fe41d0d043840f8b592d043b8607a836b846506f525a53d99d578561f02f97b2cba1d2b3c30bae5311d64b308d5a392a9930d252b906a9042fc2877da7a
@@ -7345,7 +7345,7 @@ __metadata:
 
 "log-symbols@npm:^7.0.0":
   version: 7.0.1
-  resolution: "log-symbols@npm:7.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flog-symbols%2F-%2Flog-symbols-7.0.1.tgz"
+  resolution: "log-symbols@npm:7.0.1"
   dependencies:
     is-unicode-supported: "npm:^2.0.0"
     yoctocolors: "npm:^2.1.1"
@@ -7355,7 +7355,7 @@ __metadata:
 
 "log-update@npm:^2.3.0":
   version: 2.3.0
-  resolution: "log-update@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flog-update%2F-%2Flog-update-2.3.0.tgz"
+  resolution: "log-update@npm:2.3.0"
   dependencies:
     ansi-escapes: "npm:^3.0.0"
     cli-cursor: "npm:^2.0.0"
@@ -7366,14 +7366,14 @@ __metadata:
 
 "long@npm:^5.0.0":
   version: 5.3.2
-  resolution: "long@npm:5.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flong%2F-%2Flong-5.3.2.tgz"
+  resolution: "long@npm:5.3.2"
   checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
   languageName: node
   linkType: hard
 
 "lru-cache@npm:6.0.0":
   version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flru-cache%2F-%2Flru-cache-6.0.0.tgz"
+  resolution: "lru-cache@npm:6.0.0"
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
@@ -7382,21 +7382,21 @@ __metadata:
 
 "lru-cache@npm:^10.0.1":
   version: 10.4.3
-  resolution: "lru-cache@npm:10.4.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flru-cache%2F-%2Flru-cache-10.4.3.tgz"
+  resolution: "lru-cache@npm:10.4.3"
   checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
   languageName: node
   linkType: hard
 
 "lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
   version: 11.2.4
-  resolution: "lru-cache@npm:11.2.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flru-cache%2F-%2Flru-cache-11.2.4.tgz"
+  resolution: "lru-cache@npm:11.2.4"
   checksum: 10c0/4a24f9b17537619f9144d7b8e42cd5a225efdfd7076ebe7b5e7dc02b860a818455201e67fbf000765233fe7e339d3c8229fc815e9b58ee6ede511e07608c19b2
   languageName: node
   linkType: hard
 
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
-  resolution: "lru-cache@npm:5.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flru-cache%2F-%2Flru-cache-5.1.1.tgz"
+  resolution: "lru-cache@npm:5.1.1"
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
@@ -7405,7 +7405,7 @@ __metadata:
 
 "lru-memoizer@npm:^2.2.0":
   version: 2.3.0
-  resolution: "lru-memoizer@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flru-memoizer%2F-%2Flru-memoizer-2.3.0.tgz"
+  resolution: "lru-memoizer@npm:2.3.0"
   dependencies:
     lodash.clonedeep: "npm:^4.5.0"
     lru-cache: "npm:6.0.0"
@@ -7415,7 +7415,7 @@ __metadata:
 
 "magic-regexp@npm:^0.10.0":
   version: 0.10.0
-  resolution: "magic-regexp@npm:0.10.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmagic-regexp%2F-%2Fmagic-regexp-0.10.0.tgz"
+  resolution: "magic-regexp@npm:0.10.0"
   dependencies:
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.12"
@@ -7430,7 +7430,7 @@ __metadata:
 
 "magic-string@npm:^0.30.12, magic-string@npm:^0.30.19, magic-string@npm:^0.30.4":
   version: 0.30.21
-  resolution: "magic-string@npm:0.30.21::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmagic-string%2F-%2Fmagic-string-0.30.21.tgz"
+  resolution: "magic-string@npm:0.30.21"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.5"
   checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
@@ -7439,7 +7439,7 @@ __metadata:
 
 "magicast@npm:^0.5.1":
   version: 0.5.1
-  resolution: "magicast@npm:0.5.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmagicast%2F-%2Fmagicast-0.5.1.tgz"
+  resolution: "magicast@npm:0.5.1"
   dependencies:
     "@babel/parser": "npm:^7.28.5"
     "@babel/types": "npm:^7.28.5"
@@ -7450,7 +7450,7 @@ __metadata:
 
 "make-dir@npm:^2.1.0":
   version: 2.1.0
-  resolution: "make-dir@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmake-dir%2F-%2Fmake-dir-2.1.0.tgz"
+  resolution: "make-dir@npm:2.1.0"
   dependencies:
     pify: "npm:^4.0.1"
     semver: "npm:^5.6.0"
@@ -7460,7 +7460,7 @@ __metadata:
 
 "make-dir@npm:^4.0.0":
   version: 4.0.0
-  resolution: "make-dir@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmake-dir%2F-%2Fmake-dir-4.0.0.tgz"
+  resolution: "make-dir@npm:4.0.0"
   dependencies:
     semver: "npm:^7.5.3"
   checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
@@ -7469,14 +7469,14 @@ __metadata:
 
 "make-error@npm:^1.1.1":
   version: 1.3.6
-  resolution: "make-error@npm:1.3.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmake-error%2F-%2Fmake-error-1.3.6.tgz"
+  resolution: "make-error@npm:1.3.6"
   checksum: 10c0/171e458d86854c6b3fc46610cfacf0b45149ba043782558c6875d9f42f222124384ad0b468c92e996d815a8a2003817a710c0a160e49c1c394626f76fa45396f
   languageName: node
   linkType: hard
 
 "make-fetch-happen@npm:^15.0.0":
   version: 15.0.3
-  resolution: "make-fetch-happen@npm:15.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmake-fetch-happen%2F-%2Fmake-fetch-happen-15.0.3.tgz"
+  resolution: "make-fetch-happen@npm:15.0.3"
   dependencies:
     "@npmcli/agent": "npm:^4.0.0"
     cacache: "npm:^20.0.1"
@@ -7495,56 +7495,56 @@ __metadata:
 
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
-  resolution: "math-intrinsics@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmath-intrinsics%2F-%2Fmath-intrinsics-1.1.0.tgz"
+  resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
   languageName: node
   linkType: hard
 
 "mdn-data@npm:2.0.30":
   version: 2.0.30
-  resolution: "mdn-data@npm:2.0.30::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmdn-data%2F-%2Fmdn-data-2.0.30.tgz"
+  resolution: "mdn-data@npm:2.0.30"
   checksum: 10c0/a2c472ea16cee3911ae742593715aa4c634eb3d4b9f1e6ada0902aa90df13dcbb7285d19435f3ff213ebaa3b2e0c0265c1eb0e3fb278fda7f8919f046a410cd9
   languageName: node
   linkType: hard
 
 "media-typer@npm:0.3.0":
   version: 0.3.0
-  resolution: "media-typer@npm:0.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmedia-typer%2F-%2Fmedia-typer-0.3.0.tgz"
+  resolution: "media-typer@npm:0.3.0"
   checksum: 10c0/d160f31246907e79fed398470285f21bafb45a62869dc469b1c8877f3f064f5eabc4bcc122f9479b8b605bc5c76187d7871cf84c4ee3ecd3e487da1993279928
   languageName: node
   linkType: hard
 
 "meow@npm:^13.2.0":
   version: 13.2.0
-  resolution: "meow@npm:13.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmeow%2F-%2Fmeow-13.2.0.tgz"
+  resolution: "meow@npm:13.2.0"
   checksum: 10c0/d5b339ae314715bcd0b619dd2f8a266891928e21526b4800d49b4fba1cc3fff7e2c1ff5edd3344149fac841bc2306157f858e8c4d5eaee4d52ce52ad925664ce
   languageName: node
   linkType: hard
 
 "merge-descriptors@npm:1.0.3":
   version: 1.0.3
-  resolution: "merge-descriptors@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmerge-descriptors%2F-%2Fmerge-descriptors-1.0.3.tgz"
+  resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
   languageName: node
   linkType: hard
 
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
-  resolution: "merge-stream@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmerge-stream%2F-%2Fmerge-stream-2.0.0.tgz"
+  resolution: "merge-stream@npm:2.0.0"
   checksum: 10c0/867fdbb30a6d58b011449b8885601ec1690c3e41c759ecd5a9d609094f7aed0096c37823ff4a7190ef0b8f22cc86beb7049196ff68c016e3b3c671d0dac91ce5
   languageName: node
   linkType: hard
 
 "merge2@npm:^1.3.0, merge2@npm:^1.4.1":
   version: 1.4.1
-  resolution: "merge2@npm:1.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmerge2%2F-%2Fmerge2-1.4.1.tgz"
+  resolution: "merge2@npm:1.4.1"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
   languageName: node
   linkType: hard
 
 "method-override@npm:^3.0.0":
   version: 3.0.0
-  resolution: "method-override@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmethod-override%2F-%2Fmethod-override-3.0.0.tgz"
+  resolution: "method-override@npm:3.0.0"
   dependencies:
     debug: "npm:3.1.0"
     methods: "npm:~1.1.2"
@@ -7556,14 +7556,14 @@ __metadata:
 
 "methods@npm:~1.1.2":
   version: 1.1.2
-  resolution: "methods@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmethods%2F-%2Fmethods-1.1.2.tgz"
+  resolution: "methods@npm:1.1.2"
   checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
   languageName: node
   linkType: hard
 
 "micromatch@npm:^4.0.8":
   version: 4.0.8
-  resolution: "micromatch@npm:4.0.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmicromatch%2F-%2Fmicromatch-4.0.8.tgz"
+  resolution: "micromatch@npm:4.0.8"
   dependencies:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
@@ -7573,21 +7573,21 @@ __metadata:
 
 "mime-db@npm:1.52.0":
   version: 1.52.0
-  resolution: "mime-db@npm:1.52.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmime-db%2F-%2Fmime-db-1.52.0.tgz"
+  resolution: "mime-db@npm:1.52.0"
   checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
   languageName: node
   linkType: hard
 
 "mime-db@npm:>= 1.43.0 < 2":
   version: 1.54.0
-  resolution: "mime-db@npm:1.54.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmime-db%2F-%2Fmime-db-1.54.0.tgz"
+  resolution: "mime-db@npm:1.54.0"
   checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
   languageName: node
   linkType: hard
 
 "mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34, mime-types@npm:~2.1.35":
   version: 2.1.35
-  resolution: "mime-types@npm:2.1.35::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmime-types%2F-%2Fmime-types-2.1.35.tgz"
+  resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
@@ -7596,7 +7596,7 @@ __metadata:
 
 "mime@npm:1.6.0, mime@npm:^1.4.1":
   version: 1.6.0
-  resolution: "mime@npm:1.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmime%2F-%2Fmime-1.6.0.tgz"
+  resolution: "mime@npm:1.6.0"
   bin:
     mime: cli.js
   checksum: 10c0/b92cd0adc44888c7135a185bfd0dddc42c32606401c72896a842ae15da71eb88858f17669af41e498b463cd7eb998f7b48939a25b08374c7924a9c8a6f8a81b0
@@ -7605,7 +7605,7 @@ __metadata:
 
 "mime@npm:^3.0.0":
   version: 3.0.0
-  resolution: "mime@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmime%2F-%2Fmime-3.0.0.tgz"
+  resolution: "mime@npm:3.0.0"
   bin:
     mime: cli.js
   checksum: 10c0/402e792a8df1b2cc41cb77f0dcc46472b7944b7ec29cb5bbcd398624b6b97096728f1239766d3fdeb20551dd8d94738344c195a6ea10c4f906eb0356323b0531
@@ -7614,35 +7614,35 @@ __metadata:
 
 "mimic-fn@npm:^1.0.0":
   version: 1.2.0
-  resolution: "mimic-fn@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmimic-fn%2F-%2Fmimic-fn-1.2.0.tgz"
+  resolution: "mimic-fn@npm:1.2.0"
   checksum: 10c0/ad55214aec6094c0af4c0beec1a13787556f8116ed88807cf3f05828500f21f93a9482326bcd5a077ae91e3e8795b4e76b5b4c8bb12237ff0e4043a365516cba
   languageName: node
   linkType: hard
 
 "mimic-fn@npm:^2.1.0":
   version: 2.1.0
-  resolution: "mimic-fn@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmimic-fn%2F-%2Fmimic-fn-2.1.0.tgz"
+  resolution: "mimic-fn@npm:2.1.0"
   checksum: 10c0/b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
   languageName: node
   linkType: hard
 
 "mimic-fn@npm:^4.0.0":
   version: 4.0.0
-  resolution: "mimic-fn@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmimic-fn%2F-%2Fmimic-fn-4.0.0.tgz"
+  resolution: "mimic-fn@npm:4.0.0"
   checksum: 10c0/de9cc32be9996fd941e512248338e43407f63f6d497abe8441fa33447d922e927de54d4cc3c1a3c6d652857acd770389d5a3823f311a744132760ce2be15ccbf
   languageName: node
   linkType: hard
 
 "mimic-function@npm:^5.0.0":
   version: 5.0.1
-  resolution: "mimic-function@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmimic-function%2F-%2Fmimic-function-5.0.1.tgz"
+  resolution: "mimic-function@npm:5.0.1"
   checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
   languageName: node
   linkType: hard
 
 "minimatch@npm:^10.1.1":
   version: 10.1.1
-  resolution: "minimatch@npm:10.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminimatch%2F-%2Fminimatch-10.1.1.tgz"
+  resolution: "minimatch@npm:10.1.1"
   dependencies:
     "@isaacs/brace-expansion": "npm:^5.0.0"
   checksum: 10c0/c85d44821c71973d636091fddbfbffe62370f5ee3caf0241c5b60c18cd289e916200acb2361b7e987558cd06896d153e25d505db9fc1e43e6b4b6752e2702902
@@ -7651,7 +7651,7 @@ __metadata:
 
 "minimatch@npm:^3.1.1":
   version: 3.1.2
-  resolution: "minimatch@npm:3.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminimatch%2F-%2Fminimatch-3.1.2.tgz"
+  resolution: "minimatch@npm:3.1.2"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
@@ -7660,7 +7660,7 @@ __metadata:
 
 "minimatch@npm:^9.0.0":
   version: 9.0.5
-  resolution: "minimatch@npm:9.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminimatch%2F-%2Fminimatch-9.0.5.tgz"
+  resolution: "minimatch@npm:9.0.5"
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
@@ -7669,14 +7669,14 @@ __metadata:
 
 "minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.8
-  resolution: "minimist@npm:1.2.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminimist%2F-%2Fminimist-1.2.8.tgz"
+  resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
   languageName: node
   linkType: hard
 
 "minipass-collect@npm:^2.0.1":
   version: 2.0.1
-  resolution: "minipass-collect@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass-collect%2F-%2Fminipass-collect-2.0.1.tgz"
+  resolution: "minipass-collect@npm:2.0.1"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/5167e73f62bb74cc5019594709c77e6a742051a647fe9499abf03c71dca75515b7959d67a764bdc4f8b361cf897fbf25e2d9869ee039203ed45240f48b9aa06e
@@ -7685,7 +7685,7 @@ __metadata:
 
 "minipass-fetch@npm:^5.0.0":
   version: 5.0.0
-  resolution: "minipass-fetch@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass-fetch%2F-%2Fminipass-fetch-5.0.0.tgz"
+  resolution: "minipass-fetch@npm:5.0.0"
   dependencies:
     encoding: "npm:^0.1.13"
     minipass: "npm:^7.0.3"
@@ -7700,7 +7700,7 @@ __metadata:
 
 "minipass-flush@npm:^1.0.5":
   version: 1.0.5
-  resolution: "minipass-flush@npm:1.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass-flush%2F-%2Fminipass-flush-1.0.5.tgz"
+  resolution: "minipass-flush@npm:1.0.5"
   dependencies:
     minipass: "npm:^3.0.0"
   checksum: 10c0/2a51b63feb799d2bb34669205eee7c0eaf9dce01883261a5b77410c9408aa447e478efd191b4de6fc1101e796ff5892f8443ef20d9544385819093dbb32d36bd
@@ -7709,7 +7709,7 @@ __metadata:
 
 "minipass-pipeline@npm:^1.2.4":
   version: 1.2.4
-  resolution: "minipass-pipeline@npm:1.2.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass-pipeline%2F-%2Fminipass-pipeline-1.2.4.tgz"
+  resolution: "minipass-pipeline@npm:1.2.4"
   dependencies:
     minipass: "npm:^3.0.0"
   checksum: 10c0/cbda57cea20b140b797505dc2cac71581a70b3247b84480c1fed5ca5ba46c25ecc25f68bfc9e6dcb1a6e9017dab5c7ada5eab73ad4f0a49d84e35093e0c643f2
@@ -7718,7 +7718,7 @@ __metadata:
 
 "minipass-sized@npm:^1.0.3":
   version: 1.0.3
-  resolution: "minipass-sized@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass-sized%2F-%2Fminipass-sized-1.0.3.tgz"
+  resolution: "minipass-sized@npm:1.0.3"
   dependencies:
     minipass: "npm:^3.0.0"
   checksum: 10c0/298f124753efdc745cfe0f2bdfdd81ba25b9f4e753ca4a2066eb17c821f25d48acea607dfc997633ee5bf7b6dfffb4eee4f2051eb168663f0b99fad2fa4829cb
@@ -7727,7 +7727,7 @@ __metadata:
 
 "minipass@npm:^3.0.0":
   version: 3.3.6
-  resolution: "minipass@npm:3.3.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass%2F-%2Fminipass-3.3.6.tgz"
+  resolution: "minipass@npm:3.3.6"
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/a114746943afa1dbbca8249e706d1d38b85ed1298b530f5808ce51f8e9e941962e2a5ad2e00eae7dd21d8a4aae6586a66d4216d1a259385e9d0358f0c1eba16c
@@ -7736,14 +7736,14 @@ __metadata:
 
 "minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
-  resolution: "minipass@npm:7.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminipass%2F-%2Fminipass-7.1.2.tgz"
+  resolution: "minipass@npm:7.1.2"
   checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
   languageName: node
   linkType: hard
 
 "minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
   version: 3.1.0
-  resolution: "minizlib@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fminizlib%2F-%2Fminizlib-3.1.0.tgz"
+  resolution: "minizlib@npm:3.1.0"
   dependencies:
     minipass: "npm:^7.1.2"
   checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
@@ -7752,14 +7752,14 @@ __metadata:
 
 "mitt@npm:^3.0.1":
   version: 3.0.1
-  resolution: "mitt@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmitt%2F-%2Fmitt-3.0.1.tgz"
+  resolution: "mitt@npm:3.0.1"
   checksum: 10c0/3ab4fdecf3be8c5255536faa07064d05caa3dd332bd318ff02e04621f7b3069ca1de9106cfe8e7ced675abfc2bec2ce4c4ef321c4a1bb1fb29df8ae090741913
   languageName: node
   linkType: hard
 
 "mkdirp@npm:^1.0.4":
   version: 1.0.4
-  resolution: "mkdirp@npm:1.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmkdirp%2F-%2Fmkdirp-1.0.4.tgz"
+  resolution: "mkdirp@npm:1.0.4"
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
@@ -7768,7 +7768,7 @@ __metadata:
 
 "mlly@npm:^1.7.2, mlly@npm:^1.7.4":
   version: 1.8.0
-  resolution: "mlly@npm:1.8.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmlly%2F-%2Fmlly-1.8.0.tgz"
+  resolution: "mlly@npm:1.8.0"
   dependencies:
     acorn: "npm:^8.15.0"
     pathe: "npm:^2.0.3"
@@ -7780,56 +7780,56 @@ __metadata:
 
 "mri@npm:^1.2.0":
   version: 1.2.0
-  resolution: "mri@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmri%2F-%2Fmri-1.2.0.tgz"
+  resolution: "mri@npm:1.2.0"
   checksum: 10c0/a3d32379c2554cf7351db6237ddc18dc9e54e4214953f3da105b97dc3babe0deb3ffe99cf409b38ea47cc29f9430561ba6b53b24ab8f9ce97a4b50409e4a50e7
   languageName: node
   linkType: hard
 
 "mrmime@npm:^2.0.0":
   version: 2.0.1
-  resolution: "mrmime@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmrmime%2F-%2Fmrmime-2.0.1.tgz"
+  resolution: "mrmime@npm:2.0.1"
   checksum: 10c0/af05afd95af202fdd620422f976ad67dc18e6ee29beb03dd1ce950ea6ef664de378e44197246df4c7cdd73d47f2e7143a6e26e473084b9e4aa2095c0ad1e1761
   languageName: node
   linkType: hard
 
 "ms@npm:2.0.0":
   version: 2.0.0
-  resolution: "ms@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fms%2F-%2Fms-2.0.0.tgz"
+  resolution: "ms@npm:2.0.0"
   checksum: 10c0/f8fda810b39fd7255bbdc451c46286e549794fcc700dc9cd1d25658bbc4dc2563a5de6fe7c60f798a16a60c6ceb53f033cb353f493f0cf63e5199b702943159d
   languageName: node
   linkType: hard
 
 "ms@npm:2.1.3, ms@npm:^2.1.1, ms@npm:^2.1.3, ms@npm:~2.1.3":
   version: 2.1.3
-  resolution: "ms@npm:2.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fms%2F-%2Fms-2.1.3.tgz"
+  resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
   languageName: node
   linkType: hard
 
 "mute-stream@npm:0.0.7":
   version: 0.0.7
-  resolution: "mute-stream@npm:0.0.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmute-stream%2F-%2Fmute-stream-0.0.7.tgz"
+  resolution: "mute-stream@npm:0.0.7"
   checksum: 10c0/c687cfe99289166fe17dcbd0cf49612c5d267410a7819b654a82df45016967d7b2b0b18b35410edef86de6bb089a00413557dc0182c5e78a4af50ba5d61edb42
   languageName: node
   linkType: hard
 
 "mute-stream@npm:0.0.8":
   version: 0.0.8
-  resolution: "mute-stream@npm:0.0.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmute-stream%2F-%2Fmute-stream-0.0.8.tgz"
+  resolution: "mute-stream@npm:0.0.8"
   checksum: 10c0/18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
   languageName: node
   linkType: hard
 
 "mute-stream@npm:^2.0.0":
   version: 2.0.0
-  resolution: "mute-stream@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmute-stream%2F-%2Fmute-stream-2.0.0.tgz"
+  resolution: "mute-stream@npm:2.0.0"
   checksum: 10c0/2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
   languageName: node
   linkType: hard
 
 "mz@npm:^2.7.0":
   version: 2.7.0
-  resolution: "mz@npm:2.7.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmz%2F-%2Fmz-2.7.0.tgz"
+  resolution: "mz@npm:2.7.0"
   dependencies:
     any-promise: "npm:^1.0.0"
     object-assign: "npm:^4.0.1"
@@ -7840,7 +7840,7 @@ __metadata:
 
 "nanoid@npm:^3.3.11":
   version: 3.3.11
-  resolution: "nanoid@npm:3.3.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnanoid%2F-%2Fnanoid-3.3.11.tgz"
+  resolution: "nanoid@npm:3.3.11"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
@@ -7849,7 +7849,7 @@ __metadata:
 
 "needle@npm:^3.1.0":
   version: 3.3.1
-  resolution: "needle@npm:3.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fneedle%2F-%2Fneedle-3.3.1.tgz"
+  resolution: "needle@npm:3.3.1"
   dependencies:
     iconv-lite: "npm:^0.6.3"
     sax: "npm:^1.2.4"
@@ -7861,35 +7861,35 @@ __metadata:
 
 "negotiator@npm:0.6.3":
   version: 0.6.3
-  resolution: "negotiator@npm:0.6.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnegotiator%2F-%2Fnegotiator-0.6.3.tgz"
+  resolution: "negotiator@npm:0.6.3"
   checksum: 10c0/3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
   languageName: node
   linkType: hard
 
 "negotiator@npm:^1.0.0":
   version: 1.0.0
-  resolution: "negotiator@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnegotiator%2F-%2Fnegotiator-1.0.0.tgz"
+  resolution: "negotiator@npm:1.0.0"
   checksum: 10c0/4c559dd52669ea48e1914f9d634227c561221dd54734070791f999c52ed0ff36e437b2e07d5c1f6e32909fc625fe46491c16e4a8f0572567d4dd15c3a4fda04b
   languageName: node
   linkType: hard
 
 "negotiator@npm:~0.6.4":
   version: 0.6.4
-  resolution: "negotiator@npm:0.6.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnegotiator%2F-%2Fnegotiator-0.6.4.tgz"
+  resolution: "negotiator@npm:0.6.4"
   checksum: 10c0/3e677139c7fb7628a6f36335bf11a885a62c21d5390204590a1a214a5631fcbe5ea74ef6a610b60afe84b4d975cbe0566a23f20ee17c77c73e74b80032108dea
   languageName: node
   linkType: hard
 
 "neo-async@npm:^2.6.0, neo-async@npm:^2.6.2":
   version: 2.6.2
-  resolution: "neo-async@npm:2.6.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fneo-async%2F-%2Fneo-async-2.6.2.tgz"
+  resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
   languageName: node
   linkType: hard
 
 "new-github-release-url@npm:^2.0.0":
   version: 2.0.0
-  resolution: "new-github-release-url@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnew-github-release-url%2F-%2Fnew-github-release-url-2.0.0.tgz"
+  resolution: "new-github-release-url@npm:2.0.0"
   dependencies:
     type-fest: "npm:^2.5.1"
   checksum: 10c0/9faec009b8b403efbc407f45306d07de5cc58e09df5b00bdd55b01384cd18b0fd29a97aef6915428ba3b5abb0a5c132c3507468c0c3c101e8d737c1337386786
@@ -7898,7 +7898,7 @@ __metadata:
 
 "node-addon-api@npm:^7.0.0":
   version: 7.1.1
-  resolution: "node-addon-api@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnode-addon-api%2F-%2Fnode-addon-api-7.1.1.tgz"
+  resolution: "node-addon-api@npm:7.1.1"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/fb32a206276d608037fa1bcd7e9921e177fe992fc610d098aa3128baca3c0050fc1e014fa007e9b3874cf865ddb4f5bd9f43ccb7cbbbe4efaff6a83e920b17e9
@@ -7907,7 +7907,7 @@ __metadata:
 
 "node-fetch@npm:^2.6.9, node-fetch@npm:^2.7.0":
   version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnode-fetch%2F-%2Fnode-fetch-2.7.0.tgz"
+  resolution: "node-fetch@npm:2.7.0"
   dependencies:
     whatwg-url: "npm:^5.0.0"
   peerDependencies:
@@ -7921,14 +7921,14 @@ __metadata:
 
 "node-forge@npm:^1.3.1":
   version: 1.3.3
-  resolution: "node-forge@npm:1.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnode-forge%2F-%2Fnode-forge-1.3.3.tgz"
+  resolution: "node-forge@npm:1.3.3"
   checksum: 10c0/9c6f53b0ebb34865872cf62a35b0aef8fb337e2efc766626c2e3a0040f4c02933bf29a62ba999eb44a2aca73bd512c4eda22705a47b94654b9fb8ed53db9a1db
   languageName: node
   linkType: hard
 
 "node-gyp@npm:^12.1.0":
   version: 12.1.0
-  resolution: "node-gyp@npm:12.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnode-gyp%2F-%2Fnode-gyp-12.1.0.tgz"
+  resolution: "node-gyp@npm:12.1.0"
   dependencies:
     env-paths: "npm:^2.2.0"
     exponential-backoff: "npm:^3.1.1"
@@ -7948,14 +7948,14 @@ __metadata:
 
 "node-releases@npm:^2.0.27":
   version: 2.0.27
-  resolution: "node-releases@npm:2.0.27::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnode-releases%2F-%2Fnode-releases-2.0.27.tgz"
+  resolution: "node-releases@npm:2.0.27"
   checksum: 10c0/f1e6583b7833ea81880627748d28a3a7ff5703d5409328c216ae57befbced10ce2c991bea86434e8ec39003bd017f70481e2e5f8c1f7e0a7663241f81d6e00e2
   languageName: node
   linkType: hard
 
 "nopt@npm:^9.0.0":
   version: 9.0.0
-  resolution: "nopt@npm:9.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnopt%2F-%2Fnopt-9.0.0.tgz"
+  resolution: "nopt@npm:9.0.0"
   dependencies:
     abbrev: "npm:^4.0.0"
   bin:
@@ -7966,7 +7966,7 @@ __metadata:
 
 "normalize-package-data@npm:^6.0.0":
   version: 6.0.2
-  resolution: "normalize-package-data@npm:6.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnormalize-package-data%2F-%2Fnormalize-package-data-6.0.2.tgz"
+  resolution: "normalize-package-data@npm:6.0.2"
   dependencies:
     hosted-git-info: "npm:^7.0.0"
     semver: "npm:^7.3.5"
@@ -7977,21 +7977,21 @@ __metadata:
 
 "normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
-  resolution: "normalize-path@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnormalize-path%2F-%2Fnormalize-path-3.0.0.tgz"
+  resolution: "normalize-path@npm:3.0.0"
   checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
   languageName: node
   linkType: hard
 
 "normalize-range@npm:^0.1.2":
   version: 0.1.2
-  resolution: "normalize-range@npm:0.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnormalize-range%2F-%2Fnormalize-range-0.1.2.tgz"
+  resolution: "normalize-range@npm:0.1.2"
   checksum: 10c0/bf39b73a63e0a42ad1a48c2bd1bda5a07ede64a7e2567307a407674e595bcff0fa0d57e8e5f1e7fa5e91000797c7615e13613227aaaa4d6d6e87f5bd5cc95de6
   languageName: node
   linkType: hard
 
 "np@npm:^10.0.5":
   version: 10.2.0
-  resolution: "np@npm:10.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnp%2F-%2Fnp-10.2.0.tgz"
+  resolution: "np@npm:10.2.0"
   dependencies:
     chalk: "npm:^5.4.1"
     chalk-template: "npm:^1.1.0"
@@ -8037,7 +8037,7 @@ __metadata:
 
 "npm-name@npm:^8.0.0":
   version: 8.0.0
-  resolution: "npm-name@npm:8.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnpm-name%2F-%2Fnpm-name-8.0.0.tgz"
+  resolution: "npm-name@npm:8.0.0"
   dependencies:
     is-scoped: "npm:^3.0.0"
     is-url-superb: "npm:^6.1.0"
@@ -8054,7 +8054,7 @@ __metadata:
 
 "npm-run-path@npm:^5.1.0":
   version: 5.3.0
-  resolution: "npm-run-path@npm:5.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnpm-run-path%2F-%2Fnpm-run-path-5.3.0.tgz"
+  resolution: "npm-run-path@npm:5.3.0"
   dependencies:
     path-key: "npm:^4.0.0"
   checksum: 10c0/124df74820c40c2eb9a8612a254ea1d557ddfab1581c3e751f825e3e366d9f00b0d76a3c94ecd8398e7f3eee193018622677e95816e8491f0797b21e30b2deba
@@ -8063,7 +8063,7 @@ __metadata:
 
 "npmlog@npm:^7.0.1":
   version: 7.0.1
-  resolution: "npmlog@npm:7.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnpmlog%2F-%2Fnpmlog-7.0.1.tgz"
+  resolution: "npmlog@npm:7.0.1"
   dependencies:
     are-we-there-yet: "npm:^4.0.0"
     console-control-strings: "npm:^1.1.0"
@@ -8075,49 +8075,49 @@ __metadata:
 
 "num2fraction@npm:^1.2.2":
   version: 1.2.2
-  resolution: "num2fraction@npm:1.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnum2fraction%2F-%2Fnum2fraction-1.2.2.tgz"
+  resolution: "num2fraction@npm:1.2.2"
   checksum: 10c0/3bf17b44af00508a2b0370146629710645c3e3ff3c052893680efe3f4a6ff5c953ce9e54734013b02b35744a49352d54fbc5d8b455fac979047ef17dd8ec74bd
   languageName: node
   linkType: hard
 
 "number-is-nan@npm:^1.0.0":
   version: 1.0.1
-  resolution: "number-is-nan@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fnumber-is-nan%2F-%2Fnumber-is-nan-1.0.1.tgz"
+  resolution: "number-is-nan@npm:1.0.1"
   checksum: 10c0/cb97149006acc5cd512c13c1838223abdf202e76ddfa059c5e8e7507aff2c3a78cd19057516885a2f6f5b576543dc4f7b6f3c997cc7df53ae26c260855466df5
   languageName: node
   linkType: hard
 
 "object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
   version: 4.1.1
-  resolution: "object-assign@npm:4.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fobject-assign%2F-%2Fobject-assign-4.1.1.tgz"
+  resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
   languageName: node
   linkType: hard
 
 "object-hash@npm:^3.0.0":
   version: 3.0.0
-  resolution: "object-hash@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fobject-hash%2F-%2Fobject-hash-3.0.0.tgz"
+  resolution: "object-hash@npm:3.0.0"
   checksum: 10c0/a06844537107b960c1c8b96cd2ac8592a265186bfa0f6ccafe0d34eabdb526f6fa81da1f37c43df7ed13b12a4ae3457a16071603bcd39d8beddb5f08c37b0f47
   languageName: node
   linkType: hard
 
 "object-inspect@npm:^1.13.3":
   version: 1.13.4
-  resolution: "object-inspect@npm:1.13.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fobject-inspect%2F-%2Fobject-inspect-1.13.4.tgz"
+  resolution: "object-inspect@npm:1.13.4"
   checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
   languageName: node
   linkType: hard
 
 "obug@npm:^2.1.1":
   version: 2.1.1
-  resolution: "obug@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fobug%2F-%2Fobug-2.1.1.tgz"
+  resolution: "obug@npm:2.1.1"
   checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
   languageName: node
   linkType: hard
 
 "on-finished@npm:~2.4.1":
   version: 2.4.1
-  resolution: "on-finished@npm:2.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fon-finished%2F-%2Fon-finished-2.4.1.tgz"
+  resolution: "on-finished@npm:2.4.1"
   dependencies:
     ee-first: "npm:1.1.1"
   checksum: 10c0/46fb11b9063782f2d9968863d9cbba33d77aa13c17f895f56129c274318b86500b22af3a160fe9995aa41317efcd22941b6eba747f718ced08d9a73afdb087b4
@@ -8126,14 +8126,14 @@ __metadata:
 
 "on-headers@npm:~1.1.0":
   version: 1.1.0
-  resolution: "on-headers@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fon-headers%2F-%2Fon-headers-1.1.0.tgz"
+  resolution: "on-headers@npm:1.1.0"
   checksum: 10c0/2c3b6b0d68ec9adbd561dc2d61c9b14da8ac03d8a2f0fd9e97bdf0600c887d5d97f664ff3be6876cf40cda6e3c587d73a4745e10b426ac50c7664fc5a0dfc0a1
   languageName: node
   linkType: hard
 
 "once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
-  resolution: "once@npm:1.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fonce%2F-%2Fonce-1.4.0.tgz"
+  resolution: "once@npm:1.4.0"
   dependencies:
     wrappy: "npm:1"
   checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
@@ -8142,7 +8142,7 @@ __metadata:
 
 "onetime@npm:^2.0.0":
   version: 2.0.1
-  resolution: "onetime@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fonetime%2F-%2Fonetime-2.0.1.tgz"
+  resolution: "onetime@npm:2.0.1"
   dependencies:
     mimic-fn: "npm:^1.0.0"
   checksum: 10c0/b4e44a8c34e70e02251bfb578a6e26d6de6eedbed106cd78211d2fd64d28b6281d54924696554e4e966559644243753ac5df73c87f283b0927533d3315696215
@@ -8151,7 +8151,7 @@ __metadata:
 
 "onetime@npm:^5.1.0":
   version: 5.1.2
-  resolution: "onetime@npm:5.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fonetime%2F-%2Fonetime-5.1.2.tgz"
+  resolution: "onetime@npm:5.1.2"
   dependencies:
     mimic-fn: "npm:^2.1.0"
   checksum: 10c0/ffcef6fbb2692c3c40749f31ea2e22677a876daea92959b8a80b521d95cca7a668c884d8b2045d1d8ee7d56796aa405c405462af112a1477594cc63531baeb8f
@@ -8160,7 +8160,7 @@ __metadata:
 
 "onetime@npm:^6.0.0":
   version: 6.0.0
-  resolution: "onetime@npm:6.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fonetime%2F-%2Fonetime-6.0.0.tgz"
+  resolution: "onetime@npm:6.0.0"
   dependencies:
     mimic-fn: "npm:^4.0.0"
   checksum: 10c0/4eef7c6abfef697dd4479345a4100c382d73c149d2d56170a54a07418c50816937ad09500e1ed1e79d235989d073a9bade8557122aee24f0576ecde0f392bb6c
@@ -8169,7 +8169,7 @@ __metadata:
 
 "onetime@npm:^7.0.0":
   version: 7.0.0
-  resolution: "onetime@npm:7.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fonetime%2F-%2Fonetime-7.0.0.tgz"
+  resolution: "onetime@npm:7.0.0"
   dependencies:
     mimic-function: "npm:^5.0.0"
   checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
@@ -8178,7 +8178,7 @@ __metadata:
 
 "open@npm:^10.0.4":
   version: 10.2.0
-  resolution: "open@npm:10.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fopen%2F-%2Fopen-10.2.0.tgz"
+  resolution: "open@npm:10.2.0"
   dependencies:
     default-browser: "npm:^5.2.1"
     define-lazy-prop: "npm:^3.0.0"
@@ -8190,28 +8190,28 @@ __metadata:
 
 "org-regex@npm:^1.0.0":
   version: 1.0.0
-  resolution: "org-regex@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Forg-regex%2F-%2Forg-regex-1.0.0.tgz"
+  resolution: "org-regex@npm:1.0.0"
   checksum: 10c0/70cd09689fc4a977fd80bc103eac5da8fb5a20899e9c2bf0f05595caf14d56e246477c3ca12aea14b1ac6766ce89efb9b11e6e13a0135722f473b5ce1533ad8c
   languageName: node
   linkType: hard
 
 "os-tmpdir@npm:~1.0.2":
   version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fos-tmpdir%2F-%2Fos-tmpdir-1.0.2.tgz"
+  resolution: "os-tmpdir@npm:1.0.2"
   checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
 "outdent@npm:^0.5.0":
   version: 0.5.0
-  resolution: "outdent@npm:0.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foutdent%2F-%2Foutdent-0.5.0.tgz"
+  resolution: "outdent@npm:0.5.0"
   checksum: 10c0/e216a4498889ba1babae06af84cdc4091f7cac86da49d22d0163b3be202a5f52efcd2bcd3dfca60a361eb3a27b4299f185c5655061b6b402552d7fcd1d040cff
   languageName: node
   linkType: hard
 
 "oxc-parser@npm:^0.96.0":
   version: 0.96.0
-  resolution: "oxc-parser@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foxc-parser%2F-%2Foxc-parser-0.96.0.tgz"
+  resolution: "oxc-parser@npm:0.96.0"
   dependencies:
     "@oxc-parser/binding-android-arm64": "npm:0.96.0"
     "@oxc-parser/binding-darwin-arm64": "npm:0.96.0"
@@ -8266,7 +8266,7 @@ __metadata:
 
 "oxc-resolver@npm:^11.13.0":
   version: 11.16.3
-  resolution: "oxc-resolver@npm:11.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foxc-resolver%2F-%2Foxc-resolver-11.16.3.tgz"
+  resolution: "oxc-resolver@npm:11.16.3"
   dependencies:
     "@oxc-resolver/binding-android-arm-eabi": "npm:11.16.3"
     "@oxc-resolver/binding-android-arm64": "npm:11.16.3"
@@ -8335,7 +8335,7 @@ __metadata:
 
 "oxc-walker@npm:^0.5.2":
   version: 0.5.2
-  resolution: "oxc-walker@npm:0.5.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foxc-walker%2F-%2Foxc-walker-0.5.2.tgz"
+  resolution: "oxc-walker@npm:0.5.2"
   dependencies:
     magic-regexp: "npm:^0.10.0"
   peerDependencies:
@@ -8346,7 +8346,7 @@ __metadata:
 
 "oxlint@npm:^1.25.0":
   version: 1.39.0
-  resolution: "oxlint@npm:1.39.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foxlint%2F-%2Foxlint-1.39.0.tgz"
+  resolution: "oxlint@npm:1.39.0"
   dependencies:
     "@oxlint/darwin-arm64": "npm:1.39.0"
     "@oxlint/darwin-x64": "npm:1.39.0"
@@ -8386,7 +8386,7 @@ __metadata:
 
 "p-filter@npm:^2.1.0":
   version: 2.1.0
-  resolution: "p-filter@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-filter%2F-%2Fp-filter-2.1.0.tgz"
+  resolution: "p-filter@npm:2.1.0"
   dependencies:
     p-map: "npm:^2.0.0"
   checksum: 10c0/5ac34b74b3b691c04212d5dd2319ed484f591c557a850a3ffc93a08cb38c4f5540be059c6b10a185773c479ca583a91ea00c7d6c9958c815e6b74d052f356645
@@ -8395,7 +8395,7 @@ __metadata:
 
 "p-limit@npm:^2.2.0":
   version: 2.3.0
-  resolution: "p-limit@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-limit%2F-%2Fp-limit-2.3.0.tgz"
+  resolution: "p-limit@npm:2.3.0"
   dependencies:
     p-try: "npm:^2.0.0"
   checksum: 10c0/8da01ac53efe6a627080fafc127c873da40c18d87b3f5d5492d465bb85ec7207e153948df6b9cbaeb130be70152f874229b8242ee2be84c0794082510af97f12
@@ -8404,7 +8404,7 @@ __metadata:
 
 "p-limit@npm:^3.0.1":
   version: 3.1.0
-  resolution: "p-limit@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-limit%2F-%2Fp-limit-3.1.0.tgz"
+  resolution: "p-limit@npm:3.1.0"
   dependencies:
     yocto-queue: "npm:^0.1.0"
   checksum: 10c0/9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
@@ -8413,7 +8413,7 @@ __metadata:
 
 "p-locate@npm:^4.1.0":
   version: 4.1.0
-  resolution: "p-locate@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-locate%2F-%2Fp-locate-4.1.0.tgz"
+  resolution: "p-locate@npm:4.1.0"
   dependencies:
     p-limit: "npm:^2.2.0"
   checksum: 10c0/1b476ad69ad7f6059744f343b26d51ce091508935c1dbb80c4e0a2f397ffce0ca3a1f9f5cd3c7ce19d7929a09719d5c65fe70d8ee289c3f267cd36f2881813e9
@@ -8422,21 +8422,21 @@ __metadata:
 
 "p-map@npm:^2.0.0":
   version: 2.1.0
-  resolution: "p-map@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-map%2F-%2Fp-map-2.1.0.tgz"
+  resolution: "p-map@npm:2.1.0"
   checksum: 10c0/735dae87badd4737a2dd582b6d8f93e49a1b79eabbc9815a4d63a528d5e3523e978e127a21d784cccb637010e32103a40d2aaa3ab23ae60250b1a820ca752043
   languageName: node
   linkType: hard
 
 "p-map@npm:^7.0.1, p-map@npm:^7.0.2":
   version: 7.0.4
-  resolution: "p-map@npm:7.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-map%2F-%2Fp-map-7.0.4.tgz"
+  resolution: "p-map@npm:7.0.4"
   checksum: 10c0/a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
   languageName: node
   linkType: hard
 
 "p-memoize@npm:^7.1.1":
   version: 7.1.1
-  resolution: "p-memoize@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-memoize%2F-%2Fp-memoize-7.1.1.tgz"
+  resolution: "p-memoize@npm:7.1.1"
   dependencies:
     mimic-fn: "npm:^4.0.0"
     type-fest: "npm:^3.0.0"
@@ -8446,14 +8446,14 @@ __metadata:
 
 "p-reduce@npm:^2.1.0":
   version: 2.1.0
-  resolution: "p-reduce@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-reduce%2F-%2Fp-reduce-2.1.0.tgz"
+  resolution: "p-reduce@npm:2.1.0"
   checksum: 10c0/27b8ff0fb044995507a06cd6357dffba0f2b98862864745972562a21885d7906ce5c794036d2aaa63ef6303158e41e19aed9f19651dfdafb38548ecec7d0de15
   languageName: node
   linkType: hard
 
 "p-series@npm:^2.1.0":
   version: 2.1.0
-  resolution: "p-series@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-series%2F-%2Fp-series-2.1.0.tgz"
+  resolution: "p-series@npm:2.1.0"
   dependencies:
     "@sindresorhus/is": "npm:^0.15.0"
     p-reduce: "npm:^2.1.0"
@@ -8463,14 +8463,14 @@ __metadata:
 
 "p-timeout@npm:^6.1.4":
   version: 6.1.4
-  resolution: "p-timeout@npm:6.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-timeout%2F-%2Fp-timeout-6.1.4.tgz"
+  resolution: "p-timeout@npm:6.1.4"
   checksum: 10c0/019edad1c649ab07552aa456e40ce7575c4b8ae863191477f02ac8d283ac8c66cedef0ca93422735130477a051dfe952ba717641673fd3599befdd13f63bcc33
   languageName: node
   linkType: hard
 
 "p-try@npm:^2.0.0":
   version: 2.2.0
-  resolution: "p-try@npm:2.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-try%2F-%2Fp-try-2.2.0.tgz"
+  resolution: "p-try@npm:2.2.0"
   checksum: 10c0/c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
   languageName: node
   linkType: hard
@@ -8545,14 +8545,14 @@ __metadata:
 
 "package-json-from-dist@npm:^1.0.1":
   version: 1.0.1
-  resolution: "package-json-from-dist@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpackage-json-from-dist%2F-%2Fpackage-json-from-dist-1.0.1.tgz"
+  resolution: "package-json-from-dist@npm:1.0.1"
   checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
   languageName: node
   linkType: hard
 
 "package-json@npm:^10.0.0":
   version: 10.0.1
-  resolution: "package-json@npm:10.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpackage-json%2F-%2Fpackage-json-10.0.1.tgz"
+  resolution: "package-json@npm:10.0.1"
   dependencies:
     ky: "npm:^1.2.0"
     registry-auth-token: "npm:^5.0.2"
@@ -8564,7 +8564,7 @@ __metadata:
 
 "package-manager-detector@npm:^0.2.0":
   version: 0.2.11
-  resolution: "package-manager-detector@npm:0.2.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpackage-manager-detector%2F-%2Fpackage-manager-detector-0.2.11.tgz"
+  resolution: "package-manager-detector@npm:0.2.11"
   dependencies:
     quansync: "npm:^0.2.7"
   checksum: 10c0/247991de461b9e731f3463b7dae9ce187e53095b7b94d7d96eec039abf418b61ccf74464bec1d0c11d97311f33472e77baccd4c5898f77358da4b5b33395e0b1
@@ -8573,7 +8573,7 @@ __metadata:
 
 "parent-module@npm:^1.0.0":
   version: 1.0.1
-  resolution: "parent-module@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fparent-module%2F-%2Fparent-module-1.0.1.tgz"
+  resolution: "parent-module@npm:1.0.1"
   dependencies:
     callsites: "npm:^3.0.0"
   checksum: 10c0/c63d6e80000d4babd11978e0d3fee386ca7752a02b035fd2435960ffaa7219dc42146f07069fb65e6e8bf1caef89daf9af7535a39bddf354d78bf50d8294f556
@@ -8582,7 +8582,7 @@ __metadata:
 
 "parse-json@npm:^5.2.0":
   version: 5.2.0
-  resolution: "parse-json@npm:5.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fparse-json%2F-%2Fparse-json-5.2.0.tgz"
+  resolution: "parse-json@npm:5.2.0"
   dependencies:
     "@babel/code-frame": "npm:^7.0.0"
     error-ex: "npm:^1.3.1"
@@ -8594,7 +8594,7 @@ __metadata:
 
 "parse-json@npm:^8.0.0":
   version: 8.3.0
-  resolution: "parse-json@npm:8.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fparse-json%2F-%2Fparse-json-8.3.0.tgz"
+  resolution: "parse-json@npm:8.3.0"
   dependencies:
     "@babel/code-frame": "npm:^7.26.2"
     index-to-position: "npm:^1.1.0"
@@ -8605,70 +8605,70 @@ __metadata:
 
 "parse-node-version@npm:^1.0.1":
   version: 1.0.1
-  resolution: "parse-node-version@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fparse-node-version%2F-%2Fparse-node-version-1.0.1.tgz"
+  resolution: "parse-node-version@npm:1.0.1"
   checksum: 10c0/999cd3d7da1425c2e182dce82b226c6dc842562d3ed79ec47f5c719c32a7f6c1a5352495b894fc25df164be7f2ede4224758255da9902ddef81f2b77ba46bb2c
   languageName: node
   linkType: hard
 
 "parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
   version: 1.3.3
-  resolution: "parseurl@npm:1.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fparseurl%2F-%2Fparseurl-1.3.3.tgz"
+  resolution: "parseurl@npm:1.3.3"
   checksum: 10c0/90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
   languageName: node
   linkType: hard
 
 "path-browserify@npm:1.0.1":
   version: 1.0.1
-  resolution: "path-browserify@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-browserify%2F-%2Fpath-browserify-1.0.1.tgz"
+  resolution: "path-browserify@npm:1.0.1"
   checksum: 10c0/8b8c3fd5c66bd340272180590ae4ff139769e9ab79522e2eb82e3d571a89b8117c04147f65ad066dccfb42fcad902e5b7d794b3d35e0fd840491a8ddbedf8c66
   languageName: node
   linkType: hard
 
 "path-exists@npm:^4.0.0":
   version: 4.0.0
-  resolution: "path-exists@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-exists%2F-%2Fpath-exists-4.0.0.tgz"
+  resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
   languageName: node
   linkType: hard
 
 "path-exists@npm:^5.0.0":
   version: 5.0.0
-  resolution: "path-exists@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-exists%2F-%2Fpath-exists-5.0.0.tgz"
+  resolution: "path-exists@npm:5.0.0"
   checksum: 10c0/b170f3060b31604cde93eefdb7392b89d832dfbc1bed717c9718cbe0f230c1669b7e75f87e19901da2250b84d092989a0f9e44d2ef41deb09aa3ad28e691a40a
   languageName: node
   linkType: hard
 
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
-  resolution: "path-is-absolute@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-is-absolute%2F-%2Fpath-is-absolute-1.0.1.tgz"
+  resolution: "path-is-absolute@npm:1.0.1"
   checksum: 10c0/127da03c82172a2a50099cddbf02510c1791fc2cc5f7713ddb613a56838db1e8168b121a920079d052e0936c23005562059756d653b7c544c53185efe53be078
   languageName: node
   linkType: hard
 
 "path-key@npm:^3.1.0":
   version: 3.1.1
-  resolution: "path-key@npm:3.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-key%2F-%2Fpath-key-3.1.1.tgz"
+  resolution: "path-key@npm:3.1.1"
   checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
   languageName: node
   linkType: hard
 
 "path-key@npm:^4.0.0":
   version: 4.0.0
-  resolution: "path-key@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-key%2F-%2Fpath-key-4.0.0.tgz"
+  resolution: "path-key@npm:4.0.0"
   checksum: 10c0/794efeef32863a65ac312f3c0b0a99f921f3e827ff63afa5cb09a377e202c262b671f7b3832a4e64731003fa94af0263713962d317b9887bd1e0c48a342efba3
   languageName: node
   linkType: hard
 
 "path-parse@npm:^1.0.7":
   version: 1.0.7
-  resolution: "path-parse@npm:1.0.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-parse%2F-%2Fpath-parse-1.0.7.tgz"
+  resolution: "path-parse@npm:1.0.7"
   checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
   languageName: node
   linkType: hard
 
 "path-scurry@npm:^2.0.0":
   version: 2.0.1
-  resolution: "path-scurry@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-scurry%2F-%2Fpath-scurry-2.0.1.tgz"
+  resolution: "path-scurry@npm:2.0.1"
   dependencies:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
@@ -8678,42 +8678,42 @@ __metadata:
 
 "path-to-regexp@npm:^6.2.1":
   version: 6.3.0
-  resolution: "path-to-regexp@npm:6.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-to-regexp%2F-%2Fpath-to-regexp-6.3.0.tgz"
+  resolution: "path-to-regexp@npm:6.3.0"
   checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 
 "path-to-regexp@npm:~0.1.12":
   version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-to-regexp%2F-%2Fpath-to-regexp-0.1.12.tgz"
+  resolution: "path-to-regexp@npm:0.1.12"
   checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
   languageName: node
   linkType: hard
 
 "path-type@npm:^4.0.0":
   version: 4.0.0
-  resolution: "path-type@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-type%2F-%2Fpath-type-4.0.0.tgz"
+  resolution: "path-type@npm:4.0.0"
   checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
   languageName: node
   linkType: hard
 
 "path-type@npm:^6.0.0":
   version: 6.0.0
-  resolution: "path-type@npm:6.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpath-type%2F-%2Fpath-type-6.0.0.tgz"
+  resolution: "path-type@npm:6.0.0"
   checksum: 10c0/55baa8b1187d6dc683d5a9cfcc866168d6adff58e5db91126795376d818eee46391e00b2a4d53e44d844c7524a7d96aa68cc68f4f3e500d3d069a39e6535481c
   languageName: node
   linkType: hard
 
 "pathe@npm:^2.0.1, pathe@npm:^2.0.3":
   version: 2.0.3
-  resolution: "pathe@npm:2.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpathe%2F-%2Fpathe-2.0.3.tgz"
+  resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
   languageName: node
   linkType: hard
 
 "periscopic@npm:^3.1.0":
   version: 3.1.0
-  resolution: "periscopic@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fperiscopic%2F-%2Fperiscopic-3.1.0.tgz"
+  resolution: "periscopic@npm:3.1.0"
   dependencies:
     "@types/estree": "npm:^1.0.0"
     estree-walker: "npm:^3.0.0"
@@ -8724,49 +8724,49 @@ __metadata:
 
 "picocolors@npm:^0.2.1":
   version: 0.2.1
-  resolution: "picocolors@npm:0.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpicocolors%2F-%2Fpicocolors-0.2.1.tgz"
+  resolution: "picocolors@npm:0.2.1"
   checksum: 10c0/98a83c77912c80aea0fc518aec184768501bfceafa490714b0f43eda9c52e372b844ce0a591e822bbfe5df16dcf366be7cbdb9534d39cf54a80796340371ee17
   languageName: node
   linkType: hard
 
 "picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
-  resolution: "picocolors@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpicocolors%2F-%2Fpicocolors-1.1.1.tgz"
+  resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
   languageName: node
   linkType: hard
 
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
   version: 2.3.1
-  resolution: "picomatch@npm:2.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpicomatch%2F-%2Fpicomatch-2.3.1.tgz"
+  resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
   languageName: node
   linkType: hard
 
 "picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
   version: 4.0.3
-  resolution: "picomatch@npm:4.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpicomatch%2F-%2Fpicomatch-4.0.3.tgz"
+  resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
   languageName: node
   linkType: hard
 
 "pify@npm:*, pify@npm:^6.1.0":
   version: 6.1.0
-  resolution: "pify@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpify%2F-%2Fpify-6.1.0.tgz"
+  resolution: "pify@npm:6.1.0"
   checksum: 10c0/5744905e271d821ce1c96a615aecc857bfc0154a2f55cfd773e0a27478c1e1457dd69c932f2196cfa0d298cc4a2847edaf42b1ba600b95022ba5225c079443a6
   languageName: node
   linkType: hard
 
 "pify@npm:^4.0.1":
   version: 4.0.1
-  resolution: "pify@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpify%2F-%2Fpify-4.0.1.tgz"
+  resolution: "pify@npm:4.0.1"
   checksum: 10c0/6f9d404b0d47a965437403c9b90eca8bb2536407f03de165940e62e72c8c8b75adda5516c6b9b23675a5877cc0bcac6bdfb0ef0e39414cd2476d5495da40e7cf
   languageName: node
   linkType: hard
 
 "pkg-dir@npm:^4.2.0":
   version: 4.2.0
-  resolution: "pkg-dir@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpkg-dir%2F-%2Fpkg-dir-4.2.0.tgz"
+  resolution: "pkg-dir@npm:4.2.0"
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10c0/c56bda7769e04907a88423feb320babaed0711af8c436ce3e56763ab1021ba107c7b0cafb11cde7529f669cfc22bffcaebffb573645cbd63842ea9fb17cd7728
@@ -8775,7 +8775,7 @@ __metadata:
 
 "pkg-dir@npm:^8.0.0":
   version: 8.0.0
-  resolution: "pkg-dir@npm:8.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpkg-dir%2F-%2Fpkg-dir-8.0.0.tgz"
+  resolution: "pkg-dir@npm:8.0.0"
   dependencies:
     find-up-simple: "npm:^1.0.0"
   checksum: 10c0/244c6af67540b7eeab823c56f61a6ca414fe48108a484bcb3b0743acc0dfaf106705555c353d65608ccd8ac3d9f696110e9b6bf55ef08f5f6a8d535a72a418e8
@@ -8784,7 +8784,7 @@ __metadata:
 
 "pkg-types@npm:^1.3.1":
   version: 1.3.1
-  resolution: "pkg-types@npm:1.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpkg-types%2F-%2Fpkg-types-1.3.1.tgz"
+  resolution: "pkg-types@npm:1.3.1"
   dependencies:
     confbox: "npm:^0.1.8"
     mlly: "npm:^1.7.4"
@@ -8795,7 +8795,7 @@ __metadata:
 
 "postcss-loader@npm:^8.1.0":
   version: 8.2.0
-  resolution: "postcss-loader@npm:8.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-loader%2F-%2Fpostcss-loader-8.2.0.tgz"
+  resolution: "postcss-loader@npm:8.2.0"
   dependencies:
     cosmiconfig: "npm:^9.0.0"
     jiti: "npm:^2.5.1"
@@ -8815,7 +8815,7 @@ __metadata:
 
 "postcss-modules-extract-imports@npm:^3.1.0":
   version: 3.1.0
-  resolution: "postcss-modules-extract-imports@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-modules-extract-imports%2F-%2Fpostcss-modules-extract-imports-3.1.0.tgz"
+  resolution: "postcss-modules-extract-imports@npm:3.1.0"
   peerDependencies:
     postcss: ^8.1.0
   checksum: 10c0/402084bcab376083c4b1b5111b48ec92974ef86066f366f0b2d5b2ac2b647d561066705ade4db89875a13cb175b33dd6af40d16d32b2ea5eaf8bac63bd2bf219
@@ -8824,7 +8824,7 @@ __metadata:
 
 "postcss-modules-local-by-default@npm:^4.0.5":
   version: 4.2.0
-  resolution: "postcss-modules-local-by-default@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-modules-local-by-default%2F-%2Fpostcss-modules-local-by-default-4.2.0.tgz"
+  resolution: "postcss-modules-local-by-default@npm:4.2.0"
   dependencies:
     icss-utils: "npm:^5.0.0"
     postcss-selector-parser: "npm:^7.0.0"
@@ -8837,7 +8837,7 @@ __metadata:
 
 "postcss-modules-scope@npm:^3.2.0":
   version: 3.2.1
-  resolution: "postcss-modules-scope@npm:3.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-modules-scope%2F-%2Fpostcss-modules-scope-3.2.1.tgz"
+  resolution: "postcss-modules-scope@npm:3.2.1"
   dependencies:
     postcss-selector-parser: "npm:^7.0.0"
   peerDependencies:
@@ -8848,7 +8848,7 @@ __metadata:
 
 "postcss-modules-values@npm:^4.0.0":
   version: 4.0.0
-  resolution: "postcss-modules-values@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-modules-values%2F-%2Fpostcss-modules-values-4.0.0.tgz"
+  resolution: "postcss-modules-values@npm:4.0.0"
   dependencies:
     icss-utils: "npm:^5.0.0"
   peerDependencies:
@@ -8859,7 +8859,7 @@ __metadata:
 
 "postcss-selector-parser@npm:^7.0.0":
   version: 7.1.1
-  resolution: "postcss-selector-parser@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-selector-parser%2F-%2Fpostcss-selector-parser-7.1.1.tgz"
+  resolution: "postcss-selector-parser@npm:7.1.1"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
@@ -8869,14 +8869,14 @@ __metadata:
 
 "postcss-value-parser@npm:^4.1.0, postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
-  resolution: "postcss-value-parser@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss-value-parser%2F-%2Fpostcss-value-parser-4.2.0.tgz"
+  resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
   languageName: node
   linkType: hard
 
 "postcss@npm:7.x.x, postcss@npm:^7.0.32":
   version: 7.0.39
-  resolution: "postcss@npm:7.0.39::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss%2F-%2Fpostcss-7.0.39.tgz"
+  resolution: "postcss@npm:7.0.39"
   dependencies:
     picocolors: "npm:^0.2.1"
     source-map: "npm:^0.6.1"
@@ -8886,7 +8886,7 @@ __metadata:
 
 "postcss@npm:^8.4.0, postcss@npm:^8.4.33, postcss@npm:^8.5.6":
   version: 8.5.6
-  resolution: "postcss@npm:8.5.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpostcss%2F-%2Fpostcss-8.5.6.tgz"
+  resolution: "postcss@npm:8.5.6"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
@@ -8897,14 +8897,14 @@ __metadata:
 
 "presentable-error@npm:^0.0.1":
   version: 0.0.1
-  resolution: "presentable-error@npm:0.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpresentable-error%2F-%2Fpresentable-error-0.0.1.tgz"
+  resolution: "presentable-error@npm:0.0.1"
   checksum: 10c0/84a0ef6f2c34fbb1ee006b803b9e6df52886b39ae431f0359364f8a8b74b41ca98976217fdced80bf56a9dee05fa2b456cbb57323cfc3e135bce8825ec5e8650
   languageName: node
   linkType: hard
 
 "prettier@npm:^2.7.1":
   version: 2.8.8
-  resolution: "prettier@npm:2.8.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fprettier%2F-%2Fprettier-2.8.8.tgz"
+  resolution: "prettier@npm:2.8.8"
   bin:
     prettier: bin-prettier.js
   checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
@@ -8913,7 +8913,7 @@ __metadata:
 
 "prettier@npm:^3.6.2":
   version: 3.8.0
-  resolution: "prettier@npm:3.8.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fprettier%2F-%2Fprettier-3.8.0.tgz"
+  resolution: "prettier@npm:3.8.0"
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/8926e9c9941a293b76c2d799089d038e9f6d84fb37702fc370bedd03b3c70d7fcf507e2e3c4f151f222d81820a3b74cac5e692c955cfafe34dd0d02616ce8327
@@ -8922,7 +8922,7 @@ __metadata:
 
 "pretty-quick@npm:^4.0.0":
   version: 4.2.2
-  resolution: "pretty-quick@npm:4.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpretty-quick%2F-%2Fpretty-quick-4.2.2.tgz"
+  resolution: "pretty-quick@npm:4.2.2"
   dependencies:
     "@pkgr/core": "npm:^0.2.7"
     ignore: "npm:^7.0.5"
@@ -8941,14 +8941,14 @@ __metadata:
 
 "proc-log@npm:^6.0.0":
   version: 6.1.0
-  resolution: "proc-log@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fproc-log%2F-%2Fproc-log-6.1.0.tgz"
+  resolution: "proc-log@npm:6.1.0"
   checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
   languageName: node
   linkType: hard
 
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
-  resolution: "promise-retry@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpromise-retry%2F-%2Fpromise-retry-2.0.1.tgz"
+  resolution: "promise-retry@npm:2.0.1"
   dependencies:
     err-code: "npm:^2.0.2"
     retry: "npm:^0.12.0"
@@ -8958,7 +8958,7 @@ __metadata:
 
 "promise@npm:^7.0.1":
   version: 7.3.1
-  resolution: "promise@npm:7.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpromise%2F-%2Fpromise-7.3.1.tgz"
+  resolution: "promise@npm:7.3.1"
   dependencies:
     asap: "npm:~2.0.3"
   checksum: 10c0/742e5c0cc646af1f0746963b8776299701ad561ce2c70b49365d62c8db8ea3681b0a1bf0d4e2fe07910bf72f02d39e51e8e73dc8d7503c3501206ac908be107f
@@ -8967,14 +8967,14 @@ __metadata:
 
 "proto-list@npm:~1.2.1":
   version: 1.2.4
-  resolution: "proto-list@npm:1.2.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fproto-list%2F-%2Fproto-list-1.2.4.tgz"
+  resolution: "proto-list@npm:1.2.4"
   checksum: 10c0/b9179f99394ec8a68b8afc817690185f3b03933f7b46ce2e22c1930dc84b60d09f5ad222beab4e59e58c6c039c7f7fcf620397235ef441a356f31f9744010e12
   languageName: node
   linkType: hard
 
 "proto3-json-serializer@npm:^2.0.2":
   version: 2.0.2
-  resolution: "proto3-json-serializer@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fproto3-json-serializer%2F-%2Fproto3-json-serializer-2.0.2.tgz"
+  resolution: "proto3-json-serializer@npm:2.0.2"
   dependencies:
     protobufjs: "npm:^7.2.5"
   checksum: 10c0/802e6a34f6ebf07007b186768f1985494bdfa6dd92e14c89d10cda6c4cc14df707ad59b75054a17a582f481db12c7663d25f91f505d2a85d7d4174eb5d798628
@@ -8983,7 +8983,7 @@ __metadata:
 
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
   version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fprotobufjs%2F-%2Fprotobufjs-7.5.4.tgz"
+  resolution: "protobufjs@npm:7.5.4"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -9003,7 +9003,7 @@ __metadata:
 
 "proxy-addr@npm:~2.0.7":
   version: 2.0.7
-  resolution: "proxy-addr@npm:2.0.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fproxy-addr%2F-%2Fproxy-addr-2.0.7.tgz"
+  resolution: "proxy-addr@npm:2.0.7"
   dependencies:
     forwarded: "npm:0.2.0"
     ipaddr.js: "npm:1.9.1"
@@ -9013,14 +9013,14 @@ __metadata:
 
 "prr@npm:~1.0.1":
   version: 1.0.1
-  resolution: "prr@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fprr%2F-%2Fprr-1.0.1.tgz"
+  resolution: "prr@npm:1.0.1"
   checksum: 10c0/5b9272c602e4f4472a215e58daff88f802923b84bc39c8860376bb1c0e42aaf18c25d69ad974bd06ec6db6f544b783edecd5502cd3d184748d99080d68e4be5f
   languageName: node
   linkType: hard
 
 "pug-attrs@npm:^3.0.0":
   version: 3.0.0
-  resolution: "pug-attrs@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-attrs%2F-%2Fpug-attrs-3.0.0.tgz"
+  resolution: "pug-attrs@npm:3.0.0"
   dependencies:
     constantinople: "npm:^4.0.1"
     js-stringify: "npm:^1.0.2"
@@ -9031,7 +9031,7 @@ __metadata:
 
 "pug-code-gen@npm:^3.0.3":
   version: 3.0.3
-  resolution: "pug-code-gen@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-code-gen%2F-%2Fpug-code-gen-3.0.3.tgz"
+  resolution: "pug-code-gen@npm:3.0.3"
   dependencies:
     constantinople: "npm:^4.0.1"
     doctypes: "npm:^1.1.0"
@@ -9047,14 +9047,14 @@ __metadata:
 
 "pug-error@npm:^2.0.0, pug-error@npm:^2.1.0":
   version: 2.1.0
-  resolution: "pug-error@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-error%2F-%2Fpug-error-2.1.0.tgz"
+  resolution: "pug-error@npm:2.1.0"
   checksum: 10c0/bbce339b17fab9890de84975c0cd8723a847bf65f35653d3ebcf77018e8ad91529d56e978ab80f4c64c9f4f07ef9e56e7a9fda3be44249c344a93ba11fccff79
   languageName: node
   linkType: hard
 
 "pug-filters@npm:^4.0.0":
   version: 4.0.0
-  resolution: "pug-filters@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-filters%2F-%2Fpug-filters-4.0.0.tgz"
+  resolution: "pug-filters@npm:4.0.0"
   dependencies:
     constantinople: "npm:^4.0.1"
     jstransformer: "npm:1.0.0"
@@ -9067,7 +9067,7 @@ __metadata:
 
 "pug-lexer@npm:^5.0.1":
   version: 5.0.1
-  resolution: "pug-lexer@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-lexer%2F-%2Fpug-lexer-5.0.1.tgz"
+  resolution: "pug-lexer@npm:5.0.1"
   dependencies:
     character-parser: "npm:^2.2.0"
     is-expression: "npm:^4.0.0"
@@ -9078,7 +9078,7 @@ __metadata:
 
 "pug-linker@npm:^4.0.0":
   version: 4.0.0
-  resolution: "pug-linker@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-linker%2F-%2Fpug-linker-4.0.0.tgz"
+  resolution: "pug-linker@npm:4.0.0"
   dependencies:
     pug-error: "npm:^2.0.0"
     pug-walk: "npm:^2.0.0"
@@ -9088,7 +9088,7 @@ __metadata:
 
 "pug-load@npm:^3.0.0":
   version: 3.0.0
-  resolution: "pug-load@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-load%2F-%2Fpug-load-3.0.0.tgz"
+  resolution: "pug-load@npm:3.0.0"
   dependencies:
     object-assign: "npm:^4.1.1"
     pug-walk: "npm:^2.0.0"
@@ -9098,7 +9098,7 @@ __metadata:
 
 "pug-parser@npm:^6.0.0":
   version: 6.0.0
-  resolution: "pug-parser@npm:6.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-parser%2F-%2Fpug-parser-6.0.0.tgz"
+  resolution: "pug-parser@npm:6.0.0"
   dependencies:
     pug-error: "npm:^2.0.0"
     token-stream: "npm:1.0.0"
@@ -9108,14 +9108,14 @@ __metadata:
 
 "pug-runtime@npm:^3.0.0, pug-runtime@npm:^3.0.1":
   version: 3.0.1
-  resolution: "pug-runtime@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-runtime%2F-%2Fpug-runtime-3.0.1.tgz"
+  resolution: "pug-runtime@npm:3.0.1"
   checksum: 10c0/0db8166d2e17695a6941d1de81dcb21c8a52921299b1e03bf6a0a3d2b0036b51cf98101b3937b731c745e8d3e0268cb0b728c02f61a80a25fcfaa15c594fb1be
   languageName: node
   linkType: hard
 
 "pug-strip-comments@npm:^2.0.0":
   version: 2.0.0
-  resolution: "pug-strip-comments@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-strip-comments%2F-%2Fpug-strip-comments-2.0.0.tgz"
+  resolution: "pug-strip-comments@npm:2.0.0"
   dependencies:
     pug-error: "npm:^2.0.0"
   checksum: 10c0/ca498adedaeba51dd836b20129bbd161e2d5a397a2baaa553b1e74e888caa2258dcd7326396fc6f8fed8c7b7f906cfebc4c386ccbee8888a27b2ca0d4d86d206
@@ -9124,14 +9124,14 @@ __metadata:
 
 "pug-walk@npm:^2.0.0":
   version: 2.0.0
-  resolution: "pug-walk@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug-walk%2F-%2Fpug-walk-2.0.0.tgz"
+  resolution: "pug-walk@npm:2.0.0"
   checksum: 10c0/005d63177bcf057f5a618b182f6d4600afb039200b07a381a0d89288a2b3126e763a0a6c40b758eab0731c8e63cad1bbcb46d96803b9ae9cfc879f6ef5a0f8f4
   languageName: node
   linkType: hard
 
 "pug@npm:^3.0.2":
   version: 3.0.3
-  resolution: "pug@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpug%2F-%2Fpug-3.0.3.tgz"
+  resolution: "pug@npm:3.0.3"
   dependencies:
     pug-code-gen: "npm:^3.0.3"
     pug-filters: "npm:^4.0.0"
@@ -9147,7 +9147,7 @@ __metadata:
 
 "pupa@npm:^3.1.0":
   version: 3.3.0
-  resolution: "pupa@npm:3.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpupa%2F-%2Fpupa-3.3.0.tgz"
+  resolution: "pupa@npm:3.3.0"
   dependencies:
     escape-goat: "npm:^4.0.0"
   checksum: 10c0/9707e0a7f00e5922d47527d1c8d88d4224b1e86502da2fca27943eb0e9bb218121c91fa0af6c30531a2ee5ade0c326b5d33c40fdf61bc593c4224027412fd9b7
@@ -9156,7 +9156,7 @@ __metadata:
 
 "qs@npm:^6.11.0":
   version: 6.15.0
-  resolution: "qs@npm:6.15.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fqs%2F-%2Fqs-6.15.0.tgz"
+  resolution: "qs@npm:6.15.0"
   dependencies:
     side-channel: "npm:^1.1.0"
   checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
@@ -9165,7 +9165,7 @@ __metadata:
 
 "qs@npm:~6.14.0":
   version: 6.14.2
-  resolution: "qs@npm:6.14.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fqs%2F-%2Fqs-6.14.2.tgz"
+  resolution: "qs@npm:6.14.2"
   dependencies:
     side-channel: "npm:^1.1.0"
   checksum: 10c0/646110124476fc9acf3c80994c8c3a0600cbad06a4ede1c9e93341006e8426d64e85e048baf8f0c4995f0f1bf0f37d1f3acc5ec1455850b81978792969a60ef6
@@ -9174,35 +9174,35 @@ __metadata:
 
 "quansync@npm:^0.2.7":
   version: 0.2.11
-  resolution: "quansync@npm:0.2.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fquansync%2F-%2Fquansync-0.2.11.tgz"
+  resolution: "quansync@npm:0.2.11"
   checksum: 10c0/cb9a1f8ebce074069f2f6a78578873ffedd9de9f6aa212039b44c0870955c04a71c3b1311b5d97f8ac2f2ec476de202d0a5c01160cb12bc0a11b7ef36d22ef56
   languageName: node
   linkType: hard
 
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
-  resolution: "queue-microtask@npm:1.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fqueue-microtask%2F-%2Fqueue-microtask-1.2.3.tgz"
+  resolution: "queue-microtask@npm:1.2.3"
   checksum: 10c0/900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
   languageName: node
   linkType: hard
 
 "random-bytes@npm:~1.0.0":
   version: 1.0.0
-  resolution: "random-bytes@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frandom-bytes%2F-%2Frandom-bytes-1.0.0.tgz"
+  resolution: "random-bytes@npm:1.0.0"
   checksum: 10c0/71e7a600e0976e9ebc269793a0577d47b965fa678fcc9e9623e427f909d1b3669db5b3a178dbf61229f0724ea23dba64db389f0be0ba675c6a6b837c02f29b8f
   languageName: node
   linkType: hard
 
 "range-parser@npm:~1.2.1":
   version: 1.2.1
-  resolution: "range-parser@npm:1.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frange-parser%2F-%2Frange-parser-1.2.1.tgz"
+  resolution: "range-parser@npm:1.2.1"
   checksum: 10c0/96c032ac2475c8027b7a4e9fe22dc0dfe0f6d90b85e496e0f016fbdb99d6d066de0112e680805075bd989905e2123b3b3d002765149294dce0c1f7f01fcc2ea0
   languageName: node
   linkType: hard
 
 "raw-body@npm:~2.5.3":
   version: 2.5.3
-  resolution: "raw-body@npm:2.5.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fraw-body%2F-%2Fraw-body-2.5.3.tgz"
+  resolution: "raw-body@npm:2.5.3"
   dependencies:
     bytes: "npm:~3.1.2"
     http-errors: "npm:~2.0.1"
@@ -9214,7 +9214,7 @@ __metadata:
 
 "rc@npm:1.2.8":
   version: 1.2.8
-  resolution: "rc@npm:1.2.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frc%2F-%2Frc-1.2.8.tgz"
+  resolution: "rc@npm:1.2.8"
   dependencies:
     deep-extend: "npm:^0.6.0"
     ini: "npm:~1.3.0"
@@ -9228,7 +9228,7 @@ __metadata:
 
 "read-package-up@npm:^11.0.0":
   version: 11.0.0
-  resolution: "read-package-up@npm:11.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fread-package-up%2F-%2Fread-package-up-11.0.0.tgz"
+  resolution: "read-package-up@npm:11.0.0"
   dependencies:
     find-up-simple: "npm:^1.0.0"
     read-pkg: "npm:^9.0.0"
@@ -9239,7 +9239,7 @@ __metadata:
 
 "read-pkg@npm:^9.0.0, read-pkg@npm:^9.0.1":
   version: 9.0.1
-  resolution: "read-pkg@npm:9.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fread-pkg%2F-%2Fread-pkg-9.0.1.tgz"
+  resolution: "read-pkg@npm:9.0.1"
   dependencies:
     "@types/normalize-package-data": "npm:^2.4.3"
     normalize-package-data: "npm:^6.0.0"
@@ -9252,7 +9252,7 @@ __metadata:
 
 "read-yaml-file@npm:^1.1.0":
   version: 1.1.0
-  resolution: "read-yaml-file@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fread-yaml-file%2F-%2Fread-yaml-file-1.1.0.tgz"
+  resolution: "read-yaml-file@npm:1.1.0"
   dependencies:
     graceful-fs: "npm:^4.1.5"
     js-yaml: "npm:^3.6.1"
@@ -9264,7 +9264,7 @@ __metadata:
 
 "readable-stream@npm:^3.1.1":
   version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Freadable-stream%2F-%2Freadable-stream-3.6.2.tgz"
+  resolution: "readable-stream@npm:3.6.2"
   dependencies:
     inherits: "npm:^2.0.3"
     string_decoder: "npm:^1.1.1"
@@ -9275,14 +9275,14 @@ __metadata:
 
 "readdirp@npm:^4.0.1":
   version: 4.1.2
-  resolution: "readdirp@npm:4.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Freaddirp%2F-%2Freaddirp-4.1.2.tgz"
+  resolution: "readdirp@npm:4.1.2"
   checksum: 10c0/60a14f7619dec48c9c850255cd523e2717001b0e179dc7037cfa0895da7b9e9ab07532d324bfb118d73a710887d1e35f79c495fa91582784493e085d18c72c62
   languageName: node
   linkType: hard
 
 "readdirp@npm:~3.6.0":
   version: 3.6.0
-  resolution: "readdirp@npm:3.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Freaddirp%2F-%2Freaddirp-3.6.0.tgz"
+  resolution: "readdirp@npm:3.6.0"
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
@@ -9291,14 +9291,14 @@ __metadata:
 
 "redis-errors@npm:^1.0.0, redis-errors@npm:^1.2.0":
   version: 1.2.0
-  resolution: "redis-errors@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fredis-errors%2F-%2Fredis-errors-1.2.0.tgz"
+  resolution: "redis-errors@npm:1.2.0"
   checksum: 10c0/5b316736e9f532d91a35bff631335137a4f974927bb2fb42bf8c2f18879173a211787db8ac4c3fde8f75ed6233eb0888e55d52510b5620e30d69d7d719c8b8a7
   languageName: node
   linkType: hard
 
 "redis-parser@npm:^3.0.0":
   version: 3.0.0
-  resolution: "redis-parser@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fredis-parser%2F-%2Fredis-parser-3.0.0.tgz"
+  resolution: "redis-parser@npm:3.0.0"
   dependencies:
     redis-errors: "npm:^1.0.0"
   checksum: 10c0/ee16ac4c7b2a60b1f42a2cdaee22b005bd4453eb2d0588b8a4939718997ae269da717434da5d570fe0b05030466eeb3f902a58cf2e8e1ca058bf6c9c596f632f
@@ -9307,7 +9307,7 @@ __metadata:
 
 "regexp-tree@npm:^0.1.27":
   version: 0.1.27
-  resolution: "regexp-tree@npm:0.1.27::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fregexp-tree%2F-%2Fregexp-tree-0.1.27.tgz"
+  resolution: "regexp-tree@npm:0.1.27"
   bin:
     regexp-tree: bin/regexp-tree
   checksum: 10c0/f636f44b4a0d93d7d6926585ecd81f63e4ce2ac895bc417b2ead0874cd36b337dcc3d0fedc63f69bf5aaeaa4340f36ca7e750c9687cceaf8087374e5284e843c
@@ -9316,7 +9316,7 @@ __metadata:
 
 "registry-auth-token@npm:^5.0.2":
   version: 5.1.1
-  resolution: "registry-auth-token@npm:5.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fregistry-auth-token%2F-%2Fregistry-auth-token-5.1.1.tgz"
+  resolution: "registry-auth-token@npm:5.1.1"
   dependencies:
     "@pnpm/npm-conf": "npm:^3.0.2"
   checksum: 10c0/86b0f7fd87d327cb4177fee69bcf96563147ea72e206bc9c7a6a50a51c785a31b83a6c45956a489ed292d23b908b2755a075d0b2f7fec1ba91b1fb800b24cee3
@@ -9325,7 +9325,7 @@ __metadata:
 
 "registry-url@npm:^6.0.1":
   version: 6.0.1
-  resolution: "registry-url@npm:6.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fregistry-url%2F-%2Fregistry-url-6.0.1.tgz"
+  resolution: "registry-url@npm:6.0.1"
   dependencies:
     rc: "npm:1.2.8"
   checksum: 10c0/66e2221c8113fc35ee9d23fe58cb516fc8d556a189fb8d6f1011a02efccc846c4c9b5075b4027b99a5d5c9ad1345ac37f297bea3c0ca30d607ec8084bf561b90
@@ -9334,14 +9334,14 @@ __metadata:
 
 "require-directory@npm:^2.1.1":
   version: 2.1.1
-  resolution: "require-directory@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frequire-directory%2F-%2Frequire-directory-2.1.1.tgz"
+  resolution: "require-directory@npm:2.1.1"
   checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
   languageName: node
   linkType: hard
 
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
-  resolution: "resolve-cwd@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fresolve-cwd%2F-%2Fresolve-cwd-3.0.0.tgz"
+  resolution: "resolve-cwd@npm:3.0.0"
   dependencies:
     resolve-from: "npm:^5.0.0"
   checksum: 10c0/e608a3ebd15356264653c32d7ecbc8fd702f94c6703ea4ac2fb81d9c359180cba0ae2e6b71faa446631ed6145454d5a56b227efc33a2d40638ac13f8beb20ee4
@@ -9350,21 +9350,21 @@ __metadata:
 
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
-  resolution: "resolve-from@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fresolve-from%2F-%2Fresolve-from-4.0.0.tgz"
+  resolution: "resolve-from@npm:4.0.0"
   checksum: 10c0/8408eec31a3112ef96e3746c37be7d64020cda07c03a920f5024e77290a218ea758b26ca9529fd7b1ad283947f34b2291c1c0f6aa0ed34acfdda9c6014c8d190
   languageName: node
   linkType: hard
 
 "resolve-from@npm:^5.0.0":
   version: 5.0.0
-  resolution: "resolve-from@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fresolve-from%2F-%2Fresolve-from-5.0.0.tgz"
+  resolution: "resolve-from@npm:5.0.0"
   checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
   languageName: node
   linkType: hard
 
 "resolve@npm:^1.0.0, resolve@npm:^1.15.1":
   version: 1.22.11
-  resolution: "resolve@npm:1.22.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fresolve%2F-%2Fresolve-1.22.11.tgz"
+  resolution: "resolve@npm:1.22.11"
   dependencies:
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
@@ -9377,7 +9377,7 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.0.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.15.1#optional!builtin<compat/resolve>":
   version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11%3A%3A__archiveUrl=https%253A%252F%252Fpackages.atlassian.com%252Fapi%252Fnpm%252Fnpm-remote%252Fresolve%252F-%252Fresolve-1.22.11.tgz#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
@@ -9390,7 +9390,7 @@ __metadata:
 
 "response-time@npm:^2.3.2":
   version: 2.3.4
-  resolution: "response-time@npm:2.3.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fresponse-time%2F-%2Fresponse-time-2.3.4.tgz"
+  resolution: "response-time@npm:2.3.4"
   dependencies:
     depd: "npm:~2.0.0"
     on-headers: "npm:~1.1.0"
@@ -9400,7 +9400,7 @@ __metadata:
 
 "restore-cursor@npm:^2.0.0":
   version: 2.0.0
-  resolution: "restore-cursor@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frestore-cursor%2F-%2Frestore-cursor-2.0.0.tgz"
+  resolution: "restore-cursor@npm:2.0.0"
   dependencies:
     onetime: "npm:^2.0.0"
     signal-exit: "npm:^3.0.2"
@@ -9410,7 +9410,7 @@ __metadata:
 
 "restore-cursor@npm:^3.1.0":
   version: 3.1.0
-  resolution: "restore-cursor@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frestore-cursor%2F-%2Frestore-cursor-3.1.0.tgz"
+  resolution: "restore-cursor@npm:3.1.0"
   dependencies:
     onetime: "npm:^5.1.0"
     signal-exit: "npm:^3.0.2"
@@ -9420,7 +9420,7 @@ __metadata:
 
 "retry-request@npm:^7.0.0":
   version: 7.0.2
-  resolution: "retry-request@npm:7.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fretry-request%2F-%2Fretry-request-7.0.2.tgz"
+  resolution: "retry-request@npm:7.0.2"
   dependencies:
     "@types/request": "npm:^2.48.8"
     extend: "npm:^3.0.2"
@@ -9431,28 +9431,28 @@ __metadata:
 
 "retry@npm:0.13.1":
   version: 0.13.1
-  resolution: "retry@npm:0.13.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fretry%2F-%2Fretry-0.13.1.tgz"
+  resolution: "retry@npm:0.13.1"
   checksum: 10c0/9ae822ee19db2163497e074ea919780b1efa00431d197c7afdb950e42bf109196774b92a49fc9821f0b8b328a98eea6017410bfc5e8a0fc19c85c6d11adb3772
   languageName: node
   linkType: hard
 
 "retry@npm:^0.12.0":
   version: 0.12.0
-  resolution: "retry@npm:0.12.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fretry%2F-%2Fretry-0.12.0.tgz"
+  resolution: "retry@npm:0.12.0"
   checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
   languageName: node
   linkType: hard
 
 "reusify@npm:^1.0.4":
   version: 1.1.0
-  resolution: "reusify@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Freusify%2F-%2Freusify-1.1.0.tgz"
+  resolution: "reusify@npm:1.1.0"
   checksum: 10c0/4eff0d4a5f9383566c7d7ec437b671cc51b25963bd61bf127c3f3d3f68e44a026d99b8d2f1ad344afff8d278a8fe70a8ea092650a716d22287e8bef7126bb2fa
   languageName: node
   linkType: hard
 
 "rimraf@npm:*, rimraf@npm:^6.1.0":
   version: 6.1.2
-  resolution: "rimraf@npm:6.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frimraf%2F-%2Frimraf-6.1.2.tgz"
+  resolution: "rimraf@npm:6.1.2"
   dependencies:
     glob: "npm:^13.0.0"
     package-json-from-dist: "npm:^1.0.1"
@@ -9464,7 +9464,7 @@ __metadata:
 
 "rimraf@npm:^2.6.1":
   version: 2.7.1
-  resolution: "rimraf@npm:2.7.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frimraf%2F-%2Frimraf-2.7.1.tgz"
+  resolution: "rimraf@npm:2.7.1"
   dependencies:
     glob: "npm:^7.1.3"
   bin:
@@ -9475,14 +9475,14 @@ __metadata:
 
 "rndm@npm:1.2.0":
   version: 1.2.0
-  resolution: "rndm@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frndm%2F-%2Frndm-1.2.0.tgz"
+  resolution: "rndm@npm:1.2.0"
   checksum: 10c0/31788f9a07659b8b13e03c3d68bfa0cf7aab811edca10ba823841db4e830ca7d7eae8decc8cfcb334bc0e974c5022dcd6a1fb9ffd72dac8fa3efa45a4f8bdde5
   languageName: node
   linkType: hard
 
 "rollup@npm:^4.43.0":
   version: 4.55.1
-  resolution: "rollup@npm:4.55.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frollup%2F-%2Frollup-4.55.1.tgz"
+  resolution: "rollup@npm:4.55.1"
   dependencies:
     "@rollup/rollup-android-arm-eabi": "npm:4.55.1"
     "@rollup/rollup-android-arm64": "npm:4.55.1"
@@ -9572,35 +9572,35 @@ __metadata:
 
 "rslog@npm:^1.2.11":
   version: 1.3.2
-  resolution: "rslog@npm:1.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frslog%2F-%2Frslog-1.3.2.tgz"
+  resolution: "rslog@npm:1.3.2"
   checksum: 10c0/18b168525f0d88f8f7d94fb143da4172c759ca3762cbe46abab39e24677901578b30a4f891fb513474903d20d3075eaedb90c4f522693e8d1f8d0f1b06355478
   languageName: node
   linkType: hard
 
 "run-applescript@npm:^7.0.0":
   version: 7.1.0
-  resolution: "run-applescript@npm:7.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frun-applescript%2F-%2Frun-applescript-7.1.0.tgz"
+  resolution: "run-applescript@npm:7.1.0"
   checksum: 10c0/ab826c57c20f244b2ee807704b1ef4ba7f566aa766481ae5922aac785e2570809e297c69afcccc3593095b538a8a77d26f2b2e9a1d9dffee24e0e039502d1a03
   languageName: node
   linkType: hard
 
 "run-async@npm:^2.2.0, run-async@npm:^2.4.0":
   version: 2.4.1
-  resolution: "run-async@npm:2.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frun-async%2F-%2Frun-async-2.4.1.tgz"
+  resolution: "run-async@npm:2.4.1"
   checksum: 10c0/35a68c8f1d9664f6c7c2e153877ca1d6e4f886e5ca067c25cdd895a6891ff3a1466ee07c63d6a9be306e9619ff7d509494e6d9c129516a36b9fd82263d579ee1
   languageName: node
   linkType: hard
 
 "run-async@npm:^4.0.6":
   version: 4.0.6
-  resolution: "run-async@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frun-async%2F-%2Frun-async-4.0.6.tgz"
+  resolution: "run-async@npm:4.0.6"
   checksum: 10c0/3e512c689d356238a06a59839deddeb09aec23bc66f780fe970fcf12b64bfc00c6880e9530ea22b8cf88a927145561f5a43343d8be87166e849ec0daaa3d4cf4
   languageName: node
   linkType: hard
 
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
-  resolution: "run-parallel@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frun-parallel%2F-%2Frun-parallel-1.2.0.tgz"
+  resolution: "run-parallel@npm:1.2.0"
   dependencies:
     queue-microtask: "npm:^1.2.2"
   checksum: 10c0/200b5ab25b5b8b7113f9901bfe3afc347e19bb7475b267d55ad0eb86a62a46d77510cb0f232507c9e5d497ebda569a08a9867d0d14f57a82ad5564d991588b39
@@ -9609,7 +9609,7 @@ __metadata:
 
 "rxjs@npm:^6.3.3, rxjs@npm:^6.4.0, rxjs@npm:^6.5.3, rxjs@npm:^6.6.0":
   version: 6.6.7
-  resolution: "rxjs@npm:6.6.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frxjs%2F-%2Frxjs-6.6.7.tgz"
+  resolution: "rxjs@npm:6.6.7"
   dependencies:
     tslib: "npm:^1.9.0"
   checksum: 10c0/e556a13a9aa89395e5c9d825eabcfa325568d9c9990af720f3f29f04a888a3b854f25845c2b55875d875381abcae2d8100af9cacdc57576e7ed6be030a01d2fe
@@ -9618,7 +9618,7 @@ __metadata:
 
 "rxjs@npm:^7.8.1, rxjs@npm:^7.8.2":
   version: 7.8.2
-  resolution: "rxjs@npm:7.8.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Frxjs%2F-%2Frxjs-7.8.2.tgz"
+  resolution: "rxjs@npm:7.8.2"
   dependencies:
     tslib: "npm:^2.1.0"
   checksum: 10c0/1fcd33d2066ada98ba8f21fcbbcaee9f0b271de1d38dc7f4e256bfbc6ffcdde68c8bfb69093de7eeb46f24b1fb820620bf0223706cff26b4ab99a7ff7b2e2c45
@@ -9627,21 +9627,21 @@ __metadata:
 
 "safe-buffer@npm:5.2.1, safe-buffer@npm:>=5.1.0, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0, safe-buffer@npm:~5.2.1":
   version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsafe-buffer%2F-%2Fsafe-buffer-5.2.1.tgz"
+  resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
   languageName: node
   linkType: hard
 
 "safer-buffer@npm:2.1.2, safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
-  resolution: "safer-buffer@npm:2.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsafer-buffer%2F-%2Fsafer-buffer-2.1.2.tgz"
+  resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
   languageName: node
   linkType: hard
 
 "sanitize-filename@npm:*, sanitize-filename@npm:^1.6.3":
   version: 1.6.3
-  resolution: "sanitize-filename@npm:1.6.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsanitize-filename%2F-%2Fsanitize-filename-1.6.3.tgz"
+  resolution: "sanitize-filename@npm:1.6.3"
   dependencies:
     truncate-utf8-bytes: "npm:^1.0.0"
   checksum: 10c0/16ff47556a6e54e228c28db096bedd303da67b030d4bea4925fd71324932d6b02c7b0446f00ad33987b25b6414f24ae968e01a1a1679ce599542e82c4b07eb1f
@@ -9650,7 +9650,7 @@ __metadata:
 
 "sass-loader@npm:^14.0.0":
   version: 14.2.1
-  resolution: "sass-loader@npm:14.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsass-loader%2F-%2Fsass-loader-14.2.1.tgz"
+  resolution: "sass-loader@npm:14.2.1"
   dependencies:
     neo-async: "npm:^2.6.2"
   peerDependencies:
@@ -9676,7 +9676,7 @@ __metadata:
 
 "sass@npm:^1.69.0":
   version: 1.97.2
-  resolution: "sass@npm:1.97.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsass%2F-%2Fsass-1.97.2.tgz"
+  resolution: "sass@npm:1.97.2"
   dependencies:
     "@parcel/watcher": "npm:^2.4.1"
     chokidar: "npm:^4.0.0"
@@ -9693,21 +9693,21 @@ __metadata:
 
 "sax@npm:^1.2.4":
   version: 1.4.4
-  resolution: "sax@npm:1.4.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsax%2F-%2Fsax-1.4.4.tgz"
+  resolution: "sax@npm:1.4.4"
   checksum: 10c0/acb642f2de02ad6ae157cbf91fb026acea80cdf92e88c0aec2aa350c7db3479f62a7365c34a58e3b70a72ce11fa856a02c38cfd27f49e83c18c9c7e1d52aee55
   languageName: node
   linkType: hard
 
 "scoped-regex@npm:^3.0.0":
   version: 3.0.0
-  resolution: "scoped-regex@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fscoped-regex%2F-%2Fscoped-regex-3.0.0.tgz"
+  resolution: "scoped-regex@npm:3.0.0"
   checksum: 10c0/484d137f4f30d531786442214e1f15b86e36929aa5b7e808e466eff365adff759cc34f450290658a47ec6d2baf0509eb94829948c0fb01625cf24436234743ab
   languageName: node
   linkType: hard
 
 "semver@npm:^7.7.3":
   version: 7.7.3
-  resolution: "semver@npm:7.7.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsemver%2F-%2Fsemver-7.7.3.tgz"
+  resolution: "semver@npm:7.7.3"
   bin:
     semver: bin/semver.js
   checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
@@ -9716,7 +9716,7 @@ __metadata:
 
 "send@npm:~0.19.0, send@npm:~0.19.1":
   version: 0.19.2
-  resolution: "send@npm:0.19.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsend%2F-%2Fsend-0.19.2.tgz"
+  resolution: "send@npm:0.19.2"
   dependencies:
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
@@ -9737,7 +9737,7 @@ __metadata:
 
 "serve-favicon@npm:^2.5.0":
   version: 2.5.1
-  resolution: "serve-favicon@npm:2.5.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fserve-favicon%2F-%2Fserve-favicon-2.5.1.tgz"
+  resolution: "serve-favicon@npm:2.5.1"
   dependencies:
     etag: "npm:~1.8.1"
     fresh: "npm:~0.5.2"
@@ -9750,7 +9750,7 @@ __metadata:
 
 "serve-index@npm:^1.9.1":
   version: 1.9.2
-  resolution: "serve-index@npm:1.9.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fserve-index%2F-%2Fserve-index-1.9.2.tgz"
+  resolution: "serve-index@npm:1.9.2"
   dependencies:
     accepts: "npm:~1.3.8"
     batch: "npm:0.6.1"
@@ -9765,7 +9765,7 @@ __metadata:
 
 "serve-static@npm:~1.16.2":
   version: 1.16.3
-  resolution: "serve-static@npm:1.16.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fserve-static%2F-%2Fserve-static-1.16.3.tgz"
+  resolution: "serve-static@npm:1.16.3"
   dependencies:
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
@@ -9777,7 +9777,7 @@ __metadata:
 
 "server@npm:^1.0.42":
   version: 1.0.42
-  resolution: "server@npm:1.0.42::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fserver%2F-%2Fserver-1.0.42.tgz"
+  resolution: "server@npm:1.0.42"
   dependencies:
     body-parser: "npm:^1.20.2"
     compression: "npm:^1.7.4"
@@ -9808,28 +9808,28 @@ __metadata:
 
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
-  resolution: "set-blocking@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fset-blocking%2F-%2Fset-blocking-2.0.0.tgz"
+  resolution: "set-blocking@npm:2.0.0"
   checksum: 10c0/9f8c1b2d800800d0b589de1477c753492de5c1548d4ade52f57f1d1f5e04af5481554d75ce5e5c43d4004b80a3eb714398d6907027dc0534177b7539119f4454
   languageName: node
   linkType: hard
 
 "setprototypeof@npm:1.1.1":
   version: 1.1.1
-  resolution: "setprototypeof@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsetprototypeof%2F-%2Fsetprototypeof-1.1.1.tgz"
+  resolution: "setprototypeof@npm:1.1.1"
   checksum: 10c0/1084b783f2d77908b0a593619e1214c2118c44c7c3277f6099dd7ca8acfc056c009e5d1b2860eae5e8b0ba9bc0a978c15613ff102ccc1093bb48aa6e0ed75e2f
   languageName: node
   linkType: hard
 
 "setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
   version: 1.2.0
-  resolution: "setprototypeof@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsetprototypeof%2F-%2Fsetprototypeof-1.2.0.tgz"
+  resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
   languageName: node
   linkType: hard
 
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
-  resolution: "shebang-command@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fshebang-command%2F-%2Fshebang-command-2.0.0.tgz"
+  resolution: "shebang-command@npm:2.0.0"
   dependencies:
     shebang-regex: "npm:^3.0.0"
   checksum: 10c0/a41692e7d89a553ef21d324a5cceb5f686d1f3c040759c50aab69688634688c5c327f26f3ecf7001ebfd78c01f3c7c0a11a7c8bfd0a8bc9f6240d4f40b224e4e
@@ -9838,14 +9838,14 @@ __metadata:
 
 "shebang-regex@npm:^3.0.0":
   version: 3.0.0
-  resolution: "shebang-regex@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fshebang-regex%2F-%2Fshebang-regex-3.0.0.tgz"
+  resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
   languageName: node
   linkType: hard
 
 "side-channel-list@npm:^1.0.0":
   version: 1.0.0
-  resolution: "side-channel-list@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fside-channel-list%2F-%2Fside-channel-list-1.0.0.tgz"
+  resolution: "side-channel-list@npm:1.0.0"
   dependencies:
     es-errors: "npm:^1.3.0"
     object-inspect: "npm:^1.13.3"
@@ -9855,7 +9855,7 @@ __metadata:
 
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
-  resolution: "side-channel-map@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fside-channel-map%2F-%2Fside-channel-map-1.0.1.tgz"
+  resolution: "side-channel-map@npm:1.0.1"
   dependencies:
     call-bound: "npm:^1.0.2"
     es-errors: "npm:^1.3.0"
@@ -9867,7 +9867,7 @@ __metadata:
 
 "side-channel-weakmap@npm:^1.0.2":
   version: 1.0.2
-  resolution: "side-channel-weakmap@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fside-channel-weakmap%2F-%2Fside-channel-weakmap-1.0.2.tgz"
+  resolution: "side-channel-weakmap@npm:1.0.2"
   dependencies:
     call-bound: "npm:^1.0.2"
     es-errors: "npm:^1.3.0"
@@ -9880,7 +9880,7 @@ __metadata:
 
 "side-channel@npm:^1.1.0":
   version: 1.1.0
-  resolution: "side-channel@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fside-channel%2F-%2Fside-channel-1.1.0.tgz"
+  resolution: "side-channel@npm:1.1.0"
   dependencies:
     es-errors: "npm:^1.3.0"
     object-inspect: "npm:^1.13.3"
@@ -9893,28 +9893,28 @@ __metadata:
 
 "siginfo@npm:^2.0.0":
   version: 2.0.0
-  resolution: "siginfo@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsiginfo%2F-%2Fsiginfo-2.0.0.tgz"
+  resolution: "siginfo@npm:2.0.0"
   checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
   languageName: node
   linkType: hard
 
 "signal-exit@npm:^3.0.2":
   version: 3.0.7
-  resolution: "signal-exit@npm:3.0.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsignal-exit%2F-%2Fsignal-exit-3.0.7.tgz"
+  resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
   languageName: node
   linkType: hard
 
 "signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
-  resolution: "signal-exit@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsignal-exit%2F-%2Fsignal-exit-4.1.0.tgz"
+  resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
   languageName: node
   linkType: hard
 
 "sirv@npm:^3.0.2":
   version: 3.0.2
-  resolution: "sirv@npm:3.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsirv%2F-%2Fsirv-3.0.2.tgz"
+  resolution: "sirv@npm:3.0.2"
   dependencies:
     "@polka/url": "npm:^1.0.0-next.24"
     mrmime: "npm:^2.0.0"
@@ -9925,35 +9925,35 @@ __metadata:
 
 "slash@npm:^3.0.0":
   version: 3.0.0
-  resolution: "slash@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fslash%2F-%2Fslash-3.0.0.tgz"
+  resolution: "slash@npm:3.0.0"
   checksum: 10c0/e18488c6a42bdfd4ac5be85b2ced3ccd0224773baae6ad42cfbb9ec74fc07f9fa8396bd35ee638084ead7a2a0818eb5e7151111544d4731ce843019dab4be47b
   languageName: node
   linkType: hard
 
 "slash@npm:^5.1.0":
   version: 5.1.0
-  resolution: "slash@npm:5.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fslash%2F-%2Fslash-5.1.0.tgz"
+  resolution: "slash@npm:5.1.0"
   checksum: 10c0/eb48b815caf0bdc390d0519d41b9e0556a14380f6799c72ba35caf03544d501d18befdeeef074bc9c052acf69654bc9e0d79d7f1de0866284137a40805299eb3
   languageName: node
   linkType: hard
 
 "slice-ansi@npm:0.0.4":
   version: 0.0.4
-  resolution: "slice-ansi@npm:0.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fslice-ansi%2F-%2Fslice-ansi-0.0.4.tgz"
+  resolution: "slice-ansi@npm:0.0.4"
   checksum: 10c0/997d4cc73e34aa8c0f60bdb71701b16c062cc4acd7a95e3b10e8c05d790eb5e735d9b470270dc6f443b1ba21492db7ceb849d5c93011d1256061bf7ed7216c7a
   languageName: node
   linkType: hard
 
 "smart-buffer@npm:^4.2.0":
   version: 4.2.0
-  resolution: "smart-buffer@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsmart-buffer%2F-%2Fsmart-buffer-4.2.0.tgz"
+  resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
   languageName: node
   linkType: hard
 
 "socket.io-adapter@npm:~2.5.2":
   version: 2.5.6
-  resolution: "socket.io-adapter@npm:2.5.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsocket.io-adapter%2F-%2Fsocket.io-adapter-2.5.6.tgz"
+  resolution: "socket.io-adapter@npm:2.5.6"
   dependencies:
     debug: "npm:~4.4.1"
     ws: "npm:~8.18.3"
@@ -9963,7 +9963,7 @@ __metadata:
 
 "socket.io-parser@npm:~4.2.4":
   version: 4.2.5
-  resolution: "socket.io-parser@npm:4.2.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsocket.io-parser%2F-%2Fsocket.io-parser-4.2.5.tgz"
+  resolution: "socket.io-parser@npm:4.2.5"
   dependencies:
     "@socket.io/component-emitter": "npm:~3.1.0"
     debug: "npm:~4.4.1"
@@ -9973,7 +9973,7 @@ __metadata:
 
 "socket.io@npm:4.8.1":
   version: 4.8.1
-  resolution: "socket.io@npm:4.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsocket.io%2F-%2Fsocket.io-4.8.1.tgz"
+  resolution: "socket.io@npm:4.8.1"
   dependencies:
     accepts: "npm:~1.3.4"
     base64id: "npm:~2.0.0"
@@ -9988,7 +9988,7 @@ __metadata:
 
 "socket.io@npm:^4.7.4":
   version: 4.8.3
-  resolution: "socket.io@npm:4.8.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsocket.io%2F-%2Fsocket.io-4.8.3.tgz"
+  resolution: "socket.io@npm:4.8.3"
   dependencies:
     accepts: "npm:~1.3.4"
     base64id: "npm:~2.0.0"
@@ -10003,7 +10003,7 @@ __metadata:
 
 "socks-proxy-agent@npm:^8.0.3":
   version: 8.0.5
-  resolution: "socks-proxy-agent@npm:8.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsocks-proxy-agent%2F-%2Fsocks-proxy-agent-8.0.5.tgz"
+  resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
     agent-base: "npm:^7.1.2"
     debug: "npm:^4.3.4"
@@ -10014,7 +10014,7 @@ __metadata:
 
 "socks@npm:^2.8.3":
   version: 2.8.7
-  resolution: "socks@npm:2.8.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsocks%2F-%2Fsocks-2.8.7.tgz"
+  resolution: "socks@npm:2.8.7"
   dependencies:
     ip-address: "npm:^10.0.1"
     smart-buffer: "npm:^4.2.0"
@@ -10024,14 +10024,14 @@ __metadata:
 
 "source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.2.1":
   version: 1.2.1
-  resolution: "source-map-js@npm:1.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsource-map-js%2F-%2Fsource-map-js-1.2.1.tgz"
+  resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 
 "source-map-support@npm:^0.5.12, source-map-support@npm:~0.5.20":
   version: 0.5.21
-  resolution: "source-map-support@npm:0.5.21::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsource-map-support%2F-%2Fsource-map-support-0.5.21.tgz"
+  resolution: "source-map-support@npm:0.5.21"
   dependencies:
     buffer-from: "npm:^1.0.0"
     source-map: "npm:^0.6.0"
@@ -10041,21 +10041,21 @@ __metadata:
 
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0":
   version: 0.6.1
-  resolution: "source-map@npm:0.6.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsource-map%2F-%2Fsource-map-0.6.1.tgz"
+  resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
   languageName: node
   linkType: hard
 
 "source-map@npm:^0.7.6":
   version: 0.7.6
-  resolution: "source-map@npm:0.7.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsource-map%2F-%2Fsource-map-0.7.6.tgz"
+  resolution: "source-map@npm:0.7.6"
   checksum: 10c0/59f6f05538539b274ba771d2e9e32f6c65451982510564438e048bc1352f019c6efcdc6dd07909b1968144941c14015c2c7d4369fb7c4d7d53ae769716dcc16c
   languageName: node
   linkType: hard
 
 "spawndamnit@npm:^3.0.1":
   version: 3.0.1
-  resolution: "spawndamnit@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspawndamnit%2F-%2Fspawndamnit-3.0.1.tgz"
+  resolution: "spawndamnit@npm:3.0.1"
   dependencies:
     cross-spawn: "npm:^7.0.5"
     signal-exit: "npm:^4.0.1"
@@ -10065,7 +10065,7 @@ __metadata:
 
 "spdx-correct@npm:^3.0.0":
   version: 3.2.0
-  resolution: "spdx-correct@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspdx-correct%2F-%2Fspdx-correct-3.2.0.tgz"
+  resolution: "spdx-correct@npm:3.2.0"
   dependencies:
     spdx-expression-parse: "npm:^3.0.0"
     spdx-license-ids: "npm:^3.0.0"
@@ -10075,14 +10075,14 @@ __metadata:
 
 "spdx-exceptions@npm:^2.1.0":
   version: 2.5.0
-  resolution: "spdx-exceptions@npm:2.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspdx-exceptions%2F-%2Fspdx-exceptions-2.5.0.tgz"
+  resolution: "spdx-exceptions@npm:2.5.0"
   checksum: 10c0/37217b7762ee0ea0d8b7d0c29fd48b7e4dfb94096b109d6255b589c561f57da93bf4e328c0290046115961b9209a8051ad9f525e48d433082fc79f496a4ea940
   languageName: node
   linkType: hard
 
 "spdx-expression-parse@npm:^3.0.0":
   version: 3.0.1
-  resolution: "spdx-expression-parse@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspdx-expression-parse%2F-%2Fspdx-expression-parse-3.0.1.tgz"
+  resolution: "spdx-expression-parse@npm:3.0.1"
   dependencies:
     spdx-exceptions: "npm:^2.1.0"
     spdx-license-ids: "npm:^3.0.0"
@@ -10092,28 +10092,28 @@ __metadata:
 
 "spdx-license-ids@npm:^3.0.0":
   version: 3.0.22
-  resolution: "spdx-license-ids@npm:3.0.22::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspdx-license-ids%2F-%2Fspdx-license-ids-3.0.22.tgz"
+  resolution: "spdx-license-ids@npm:3.0.22"
   checksum: 10c0/4a85e44c2ccfc06eebe63239193f526508ebec1abc7cf7bca8ee43923755636234395447c2c87f40fb672cf580a9c8e684513a676bfb2da3d38a4983684bbb38
   languageName: node
   linkType: hard
 
 "speakingurl@npm:^14.0.1":
   version: 14.0.1
-  resolution: "speakingurl@npm:14.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspeakingurl%2F-%2Fspeakingurl-14.0.1.tgz"
+  resolution: "speakingurl@npm:14.0.1"
   checksum: 10c0/1de1d1b938a7c4d9e79593ff7a26d312ec04a7c3234ca40b7f9b8106daf74ea9d2110a077f5db97ecf3762b83069e3ccbf9694431b51d4fcfd863f0b3333c342
   languageName: node
   linkType: hard
 
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsprintf-js%2F-%2Fsprintf-js-1.0.3.tgz"
+  resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 
 "ssri@npm:^13.0.0":
   version: 13.0.0
-  resolution: "ssri@npm:13.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fssri%2F-%2Fssri-13.0.0.tgz"
+  resolution: "ssri@npm:13.0.0"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/405f3a531cd98b013cecb355d63555dca42fd12c7bc6671738aaa9a82882ff41cdf0ef9a2b734ca4f9a760338f114c29d01d9238a65db3ccac27929bd6e6d4b2
@@ -10122,42 +10122,42 @@ __metadata:
 
 "stackback@npm:0.0.2":
   version: 0.0.2
-  resolution: "stackback@npm:0.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstackback%2F-%2Fstackback-0.0.2.tgz"
+  resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
   languageName: node
   linkType: hard
 
 "standard-as-callback@npm:^2.1.0":
   version: 2.1.0
-  resolution: "standard-as-callback@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstandard-as-callback%2F-%2Fstandard-as-callback-2.1.0.tgz"
+  resolution: "standard-as-callback@npm:2.1.0"
   checksum: 10c0/012677236e3d3fdc5689d29e64ea8a599331c4babe86956bf92fc5e127d53f85411c5536ee0079c52c43beb0026b5ce7aa1d834dd35dd026e82a15d1bcaead1f
   languageName: node
   linkType: hard
 
 "statuses@npm:>= 1.5.0 < 2":
   version: 1.5.0
-  resolution: "statuses@npm:1.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstatuses%2F-%2Fstatuses-1.5.0.tgz"
+  resolution: "statuses@npm:1.5.0"
   checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
   languageName: node
   linkType: hard
 
 "statuses@npm:~2.0.1, statuses@npm:~2.0.2":
   version: 2.0.2
-  resolution: "statuses@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstatuses%2F-%2Fstatuses-2.0.2.tgz"
+  resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
   languageName: node
   linkType: hard
 
 "std-env@npm:^3.10.0, std-env@npm:^3.9.0":
   version: 3.10.0
-  resolution: "std-env@npm:3.10.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstd-env%2F-%2Fstd-env-3.10.0.tgz"
+  resolution: "std-env@npm:3.10.0"
   checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
   languageName: node
   linkType: hard
 
 "stream-events@npm:^1.0.5":
   version: 1.0.5
-  resolution: "stream-events@npm:1.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstream-events%2F-%2Fstream-events-1.0.5.tgz"
+  resolution: "stream-events@npm:1.0.5"
   dependencies:
     stubs: "npm:^3.0.0"
   checksum: 10c0/5d235a5799a483e94ea8829526fe9d95d76460032d5e78555fe4f801949ac6a27ea2212e4e0827c55f78726b3242701768adf2d33789465f51b31ed8ebd6b086
@@ -10166,14 +10166,14 @@ __metadata:
 
 "stream-shift@npm:^1.0.2":
   version: 1.0.3
-  resolution: "stream-shift@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstream-shift%2F-%2Fstream-shift-1.0.3.tgz"
+  resolution: "stream-shift@npm:1.0.3"
   checksum: 10c0/939cd1051ca750d240a0625b106a2b988c45fb5a3be0cebe9a9858cb01bc1955e8c7b9fac17a9462976bea4a7b704e317c5c2200c70f0ca715a3363b9aa4fd3b
   languageName: node
   linkType: hard
 
 "string-width@npm:^1.0.1":
   version: 1.0.2
-  resolution: "string-width@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstring-width%2F-%2Fstring-width-1.0.2.tgz"
+  resolution: "string-width@npm:1.0.2"
   dependencies:
     code-point-at: "npm:^1.0.0"
     is-fullwidth-code-point: "npm:^1.0.0"
@@ -10184,7 +10184,7 @@ __metadata:
 
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
-  resolution: "string-width@npm:4.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstring-width%2F-%2Fstring-width-4.2.3.tgz"
+  resolution: "string-width@npm:4.2.3"
   dependencies:
     emoji-regex: "npm:^8.0.0"
     is-fullwidth-code-point: "npm:^3.0.0"
@@ -10195,7 +10195,7 @@ __metadata:
 
 "string-width@npm:^2.1.0, string-width@npm:^2.1.1":
   version: 2.1.1
-  resolution: "string-width@npm:2.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstring-width%2F-%2Fstring-width-2.1.1.tgz"
+  resolution: "string-width@npm:2.1.1"
   dependencies:
     is-fullwidth-code-point: "npm:^2.0.0"
     strip-ansi: "npm:^4.0.0"
@@ -10205,7 +10205,7 @@ __metadata:
 
 "string-width@npm:^7.0.0, string-width@npm:^7.2.0":
   version: 7.2.0
-  resolution: "string-width@npm:7.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstring-width%2F-%2Fstring-width-7.2.0.tgz"
+  resolution: "string-width@npm:7.2.0"
   dependencies:
     emoji-regex: "npm:^10.3.0"
     get-east-asian-width: "npm:^1.0.0"
@@ -10216,7 +10216,7 @@ __metadata:
 
 "string_decoder@npm:^1.1.1":
   version: 1.3.0
-  resolution: "string_decoder@npm:1.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstring_decoder%2F-%2Fstring_decoder-1.3.0.tgz"
+  resolution: "string_decoder@npm:1.3.0"
   dependencies:
     safe-buffer: "npm:~5.2.0"
   checksum: 10c0/810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
@@ -10225,7 +10225,7 @@ __metadata:
 
 "strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
   version: 3.0.1
-  resolution: "strip-ansi@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-ansi%2F-%2Fstrip-ansi-3.0.1.tgz"
+  resolution: "strip-ansi@npm:3.0.1"
   dependencies:
     ansi-regex: "npm:^2.0.0"
   checksum: 10c0/f6e7fbe8e700105dccf7102eae20e4f03477537c74b286fd22cfc970f139002ed6f0d9c10d0e21aa9ed9245e0fa3c9275930e8795c5b947da136e4ecb644a70f
@@ -10234,7 +10234,7 @@ __metadata:
 
 "strip-ansi@npm:^4.0.0":
   version: 4.0.0
-  resolution: "strip-ansi@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-ansi%2F-%2Fstrip-ansi-4.0.0.tgz"
+  resolution: "strip-ansi@npm:4.0.0"
   dependencies:
     ansi-regex: "npm:^3.0.0"
   checksum: 10c0/d75d9681e0637ea316ddbd7d4d3be010b1895a17e885155e0ed6a39755ae0fd7ef46e14b22162e66a62db122d3a98ab7917794e255532ab461bb0a04feb03e7d
@@ -10243,7 +10243,7 @@ __metadata:
 
 "strip-ansi@npm:^5.1.0":
   version: 5.2.0
-  resolution: "strip-ansi@npm:5.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-ansi%2F-%2Fstrip-ansi-5.2.0.tgz"
+  resolution: "strip-ansi@npm:5.2.0"
   dependencies:
     ansi-regex: "npm:^4.1.0"
   checksum: 10c0/de4658c8a097ce3b15955bc6008f67c0790f85748bdc025b7bc8c52c7aee94bc4f9e50624516150ed173c3db72d851826cd57e7a85fe4e4bb6dbbebd5d297fdf
@@ -10252,7 +10252,7 @@ __metadata:
 
 "strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-ansi%2F-%2Fstrip-ansi-6.0.1.tgz"
+  resolution: "strip-ansi@npm:6.0.1"
   dependencies:
     ansi-regex: "npm:^5.0.1"
   checksum: 10c0/1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
@@ -10261,7 +10261,7 @@ __metadata:
 
 "strip-ansi@npm:^7.1.0":
   version: 7.1.2
-  resolution: "strip-ansi@npm:7.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-ansi%2F-%2Fstrip-ansi-7.1.2.tgz"
+  resolution: "strip-ansi@npm:7.1.2"
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
@@ -10270,35 +10270,35 @@ __metadata:
 
 "strip-bom@npm:^3.0.0":
   version: 3.0.0
-  resolution: "strip-bom@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-bom%2F-%2Fstrip-bom-3.0.0.tgz"
+  resolution: "strip-bom@npm:3.0.0"
   checksum: 10c0/51201f50e021ef16672593d7434ca239441b7b760e905d9f33df6e4f3954ff54ec0e0a06f100d028af0982d6f25c35cd5cda2ce34eaebccd0250b8befb90d8f1
   languageName: node
   linkType: hard
 
 "strip-final-newline@npm:^3.0.0":
   version: 3.0.0
-  resolution: "strip-final-newline@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-final-newline%2F-%2Fstrip-final-newline-3.0.0.tgz"
+  resolution: "strip-final-newline@npm:3.0.0"
   checksum: 10c0/a771a17901427bac6293fd416db7577e2bc1c34a19d38351e9d5478c3c415f523f391003b42ed475f27e33a78233035df183525395f731d3bfb8cdcbd4da08ce
   languageName: node
   linkType: hard
 
 "strip-json-comments@npm:^2.0.0, strip-json-comments@npm:~2.0.1":
   version: 2.0.1
-  resolution: "strip-json-comments@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrip-json-comments%2F-%2Fstrip-json-comments-2.0.1.tgz"
+  resolution: "strip-json-comments@npm:2.0.1"
   checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
   languageName: node
   linkType: hard
 
 "strnum@npm:^1.1.1":
   version: 1.1.2
-  resolution: "strnum@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstrnum%2F-%2Fstrnum-1.1.2.tgz"
+  resolution: "strnum@npm:1.1.2"
   checksum: 10c0/a0fce2498fa3c64ce64a40dada41beb91cabe3caefa910e467dc0518ef2ebd7e4d10f8c2202a6104f1410254cae245066c0e94e2521fb4061a5cb41831952392
   languageName: node
   linkType: hard
 
 "stubborn-fs@npm:^2.0.0":
   version: 2.0.0
-  resolution: "stubborn-fs@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstubborn-fs%2F-%2Fstubborn-fs-2.0.0.tgz"
+  resolution: "stubborn-fs@npm:2.0.0"
   dependencies:
     stubborn-utils: "npm:^1.0.1"
   checksum: 10c0/31a60c9b2a61ce380b688f2649acaeff63cb0f2503bb6820c3ccd4f3af584c6310a48efa41b40c16b1717f1728572ed887c2c88650955c776a088228797e8d0e
@@ -10307,28 +10307,28 @@ __metadata:
 
 "stubborn-utils@npm:^1.0.1":
   version: 1.0.2
-  resolution: "stubborn-utils@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstubborn-utils%2F-%2Fstubborn-utils-1.0.2.tgz"
+  resolution: "stubborn-utils@npm:1.0.2"
   checksum: 10c0/e65c5820d02c993df55c88e938796c2fb2f3a6d3dc247c961d1e4be4d6d88c355283f4b74157e89d1a1a761d66b5ae79560a416384241a7d3b4e8ba8f1ff5a78
   languageName: node
   linkType: hard
 
 "stubs@npm:^3.0.0":
   version: 3.0.0
-  resolution: "stubs@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fstubs%2F-%2Fstubs-3.0.0.tgz"
+  resolution: "stubs@npm:3.0.0"
   checksum: 10c0/841a4ab8c76795d34aefe129185763b55fbf2e4693208215627caea4dd62e1299423dcd96f708d3128e3dfa0e669bae2cb912e6e906d7d81eaf6493196570923
   languageName: node
   linkType: hard
 
 "supports-color@npm:^2.0.0":
   version: 2.0.0
-  resolution: "supports-color@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsupports-color%2F-%2Fsupports-color-2.0.0.tgz"
+  resolution: "supports-color@npm:2.0.0"
   checksum: 10c0/570e0b63be36cccdd25186350a6cb2eaad332a95ff162fa06d9499982315f2fe4217e69dd98e862fbcd9c81eaff300a825a1fe7bf5cc752e5b84dfed042b0dda
   languageName: node
   linkType: hard
 
 "supports-color@npm:^5.3.0":
   version: 5.5.0
-  resolution: "supports-color@npm:5.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsupports-color%2F-%2Fsupports-color-5.5.0.tgz"
+  resolution: "supports-color@npm:5.5.0"
   dependencies:
     has-flag: "npm:^3.0.0"
   checksum: 10c0/6ae5ff319bfbb021f8a86da8ea1f8db52fac8bd4d499492e30ec17095b58af11f0c55f8577390a749b1c4dde691b6a0315dab78f5f54c9b3d83f8fb5905c1c05
@@ -10337,7 +10337,7 @@ __metadata:
 
 "supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
-  resolution: "supports-color@npm:7.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsupports-color%2F-%2Fsupports-color-7.2.0.tgz"
+  resolution: "supports-color@npm:7.2.0"
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
@@ -10346,7 +10346,7 @@ __metadata:
 
 "supports-hyperlinks@npm:^2.2.0":
   version: 2.3.0
-  resolution: "supports-hyperlinks@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsupports-hyperlinks%2F-%2Fsupports-hyperlinks-2.3.0.tgz"
+  resolution: "supports-hyperlinks@npm:2.3.0"
   dependencies:
     has-flag: "npm:^4.0.0"
     supports-color: "npm:^7.0.0"
@@ -10356,21 +10356,21 @@ __metadata:
 
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
-  resolution: "supports-preserve-symlinks-flag@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsupports-preserve-symlinks-flag%2F-%2Fsupports-preserve-symlinks-flag-1.0.0.tgz"
+  resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
   languageName: node
   linkType: hard
 
 "svelte-dev-helper@npm:^1.1.9":
   version: 1.1.9
-  resolution: "svelte-dev-helper@npm:1.1.9::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsvelte-dev-helper%2F-%2Fsvelte-dev-helper-1.1.9.tgz"
+  resolution: "svelte-dev-helper@npm:1.1.9"
   checksum: 10c0/6a154829c88f4e92de59755d3e36db468a90dbbbbfc5f3e7d10fef3d3552454e11d4145cc9fe9892105bfe66433aea60c5e087e759266edb8e8d9ec4400606ae
   languageName: node
   linkType: hard
 
 "svelte-hmr@npm:^0.14.2":
   version: 0.14.12
-  resolution: "svelte-hmr@npm:0.14.12::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsvelte-hmr%2F-%2Fsvelte-hmr-0.14.12.tgz"
+  resolution: "svelte-hmr@npm:0.14.12"
   peerDependencies:
     svelte: ">=3.19.0"
   checksum: 10c0/7e9d9980770ff5f61b3578950e142ac4093edfb1c7c64c6a20b3858c75fbc77a13a33db6f994223f1f23cf813507c4e777de1e601d9fe887bcd448805f98fce7
@@ -10379,7 +10379,7 @@ __metadata:
 
 "svelte-loader@npm:^3.1.0":
   version: 3.2.4
-  resolution: "svelte-loader@npm:3.2.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsvelte-loader%2F-%2Fsvelte-loader-3.2.4.tgz"
+  resolution: "svelte-loader@npm:3.2.4"
   dependencies:
     loader-utils: "npm:^2.0.4"
     svelte-dev-helper: "npm:^1.1.9"
@@ -10392,7 +10392,7 @@ __metadata:
 
 "svelte@npm:^4.0.0":
   version: 4.2.20
-  resolution: "svelte@npm:4.2.20::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsvelte%2F-%2Fsvelte-4.2.20.tgz"
+  resolution: "svelte@npm:4.2.20"
   dependencies:
     "@ampproject/remapping": "npm:^2.2.1"
     "@jridgewell/sourcemap-codec": "npm:^1.4.15"
@@ -10414,35 +10414,35 @@ __metadata:
 
 "symbol-observable@npm:^1.1.0":
   version: 1.2.0
-  resolution: "symbol-observable@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsymbol-observable%2F-%2Fsymbol-observable-1.2.0.tgz"
+  resolution: "symbol-observable@npm:1.2.0"
   checksum: 10c0/009fee50798ef80ed4b8195048288f108b03de162db07493f2e1fd993b33fafa72d659e832b584da5a2427daa78e5a738fb2a9ab027ee9454252e0bedbcd1fdc
   languageName: node
   linkType: hard
 
 "symbol-observable@npm:^4.0.0":
   version: 4.0.0
-  resolution: "symbol-observable@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsymbol-observable%2F-%2Fsymbol-observable-4.0.0.tgz"
+  resolution: "symbol-observable@npm:4.0.0"
   checksum: 10c0/5e9a3ab08263a6be8cbee76587ad5880dcc62a47002787ed5ebea56b1eb30dc87da6f0183d67e88286806799fbe21c69077fbd677be4be2188e92318d6c6f31d
   languageName: node
   linkType: hard
 
 "tapable@npm:2.2.3":
   version: 2.2.3
-  resolution: "tapable@npm:2.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftapable%2F-%2Ftapable-2.2.3.tgz"
+  resolution: "tapable@npm:2.2.3"
   checksum: 10c0/e57fd8e2d756c317f8726a1bec8f2c904bc42e37fcbd4a78211daeab89f42c734b6a20e61774321f47be9a421da628a0c78b62d36c5ed186f4d5232d09ae15f2
   languageName: node
   linkType: hard
 
 "tapable@npm:^2.2.0":
   version: 2.3.0
-  resolution: "tapable@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftapable%2F-%2Ftapable-2.3.0.tgz"
+  resolution: "tapable@npm:2.3.0"
   checksum: 10c0/cb9d67cc2c6a74dedc812ef3085d9d681edd2c1fa18e4aef57a3c0605fdbe44e6b8ea00bd9ef21bc74dd45314e39d31227aa031ebf2f5e38164df514136f2681
   languageName: node
   linkType: hard
 
 "tar@npm:^7.5.2":
   version: 7.5.3
-  resolution: "tar@npm:7.5.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftar%2F-%2Ftar-7.5.3.tgz"
+  resolution: "tar@npm:7.5.3"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
@@ -10455,7 +10455,7 @@ __metadata:
 
 "teeny-request@npm:^9.0.0":
   version: 9.0.0
-  resolution: "teeny-request@npm:9.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fteeny-request%2F-%2Fteeny-request-9.0.0.tgz"
+  resolution: "teeny-request@npm:9.0.0"
   dependencies:
     http-proxy-agent: "npm:^5.0.0"
     https-proxy-agent: "npm:^5.0.0"
@@ -10468,14 +10468,14 @@ __metadata:
 
 "term-size@npm:^2.1.0":
   version: 2.2.1
-  resolution: "term-size@npm:2.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fterm-size%2F-%2Fterm-size-2.2.1.tgz"
+  resolution: "term-size@npm:2.2.1"
   checksum: 10c0/89f6bba1d05d425156c0910982f9344d9e4aebf12d64bfa1f460d93c24baa7bc4c4a21d355fbd7153c316433df0538f64d0ae6e336cc4a69fdda4f85d62bc79d
   languageName: node
   linkType: hard
 
 "terminal-link@npm:^3.0.0":
   version: 3.0.0
-  resolution: "terminal-link@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fterminal-link%2F-%2Fterminal-link-3.0.0.tgz"
+  resolution: "terminal-link@npm:3.0.0"
   dependencies:
     ansi-escapes: "npm:^5.0.0"
     supports-hyperlinks: "npm:^2.2.0"
@@ -10485,7 +10485,7 @@ __metadata:
 
 "terser@npm:^5.44.0":
   version: 5.46.0
-  resolution: "terser@npm:5.46.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fterser%2F-%2Fterser-5.46.0.tgz"
+  resolution: "terser@npm:5.46.0"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.15.0"
@@ -10499,7 +10499,7 @@ __metadata:
 
 "thenify-all@npm:^1.0.0":
   version: 1.6.0
-  resolution: "thenify-all@npm:1.6.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fthenify-all%2F-%2Fthenify-all-1.6.0.tgz"
+  resolution: "thenify-all@npm:1.6.0"
   dependencies:
     thenify: "npm:>= 3.1.0 < 4"
   checksum: 10c0/9b896a22735e8122754fe70f1d65f7ee691c1d70b1f116fda04fea103d0f9b356e3676cb789506e3909ae0486a79a476e4914b0f92472c2e093d206aed4b7d6b
@@ -10508,7 +10508,7 @@ __metadata:
 
 "thenify@npm:>= 3.1.0 < 4":
   version: 3.3.1
-  resolution: "thenify@npm:3.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fthenify%2F-%2Fthenify-3.3.1.tgz"
+  resolution: "thenify@npm:3.3.1"
   dependencies:
     any-promise: "npm:^1.0.0"
   checksum: 10c0/f375aeb2b05c100a456a30bc3ed07ef03a39cbdefe02e0403fb714b8c7e57eeaad1a2f5c4ecfb9ce554ce3db9c2b024eba144843cd9e344566d9fcee73b04767
@@ -10517,28 +10517,28 @@ __metadata:
 
 "through@npm:^2.3.6, through@npm:^2.3.8":
   version: 2.3.8
-  resolution: "through@npm:2.3.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fthrough%2F-%2Fthrough-2.3.8.tgz"
+  resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
   languageName: node
   linkType: hard
 
 "tinybench@npm:^2.9.0":
   version: 2.9.0
-  resolution: "tinybench@npm:2.9.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftinybench%2F-%2Ftinybench-2.9.0.tgz"
+  resolution: "tinybench@npm:2.9.0"
   checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
   languageName: node
   linkType: hard
 
 "tinyexec@npm:^0.3.2":
   version: 0.3.2
-  resolution: "tinyexec@npm:0.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftinyexec%2F-%2Ftinyexec-0.3.2.tgz"
+  resolution: "tinyexec@npm:0.3.2"
   checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
   languageName: node
   linkType: hard
 
 "tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
   version: 0.2.15
-  resolution: "tinyglobby@npm:0.2.15::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftinyglobby%2F-%2Ftinyglobby-0.2.15.tgz"
+  resolution: "tinyglobby@npm:0.2.15"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
@@ -10548,14 +10548,14 @@ __metadata:
 
 "tinyrainbow@npm:^3.0.3":
   version: 3.0.3
-  resolution: "tinyrainbow@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftinyrainbow%2F-%2Ftinyrainbow-3.0.3.tgz"
+  resolution: "tinyrainbow@npm:3.0.3"
   checksum: 10c0/1e799d35cd23cabe02e22550985a3051dc88814a979be02dc632a159c393a998628eacfc558e4c746b3006606d54b00bcdea0c39301133956d10a27aa27e988c
   languageName: node
   linkType: hard
 
 "tmp@npm:^0.0.33":
   version: 0.0.33
-  resolution: "tmp@npm:0.0.33::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftmp%2F-%2Ftmp-0.0.33.tgz"
+  resolution: "tmp@npm:0.0.33"
   dependencies:
     os-tmpdir: "npm:~1.0.2"
   checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
@@ -10564,7 +10564,7 @@ __metadata:
 
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
-  resolution: "to-regex-range@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fto-regex-range%2F-%2Fto-regex-range-5.0.1.tgz"
+  resolution: "to-regex-range@npm:5.0.1"
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
@@ -10573,42 +10573,42 @@ __metadata:
 
 "toidentifier@npm:1.0.0":
   version: 1.0.0
-  resolution: "toidentifier@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftoidentifier%2F-%2Ftoidentifier-1.0.0.tgz"
+  resolution: "toidentifier@npm:1.0.0"
   checksum: 10c0/27a37b8b21126e7216d40c02f410065b1de35b0f844368d0ccaabba7987595703006d45e5c094b086220cbbc5864d4b99766b460110e4bc15b9db574c5c58be2
   languageName: node
   linkType: hard
 
 "toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
   version: 1.0.1
-  resolution: "toidentifier@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftoidentifier%2F-%2Ftoidentifier-1.0.1.tgz"
+  resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
   languageName: node
   linkType: hard
 
 "token-stream@npm:1.0.0":
   version: 1.0.0
-  resolution: "token-stream@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftoken-stream%2F-%2Ftoken-stream-1.0.0.tgz"
+  resolution: "token-stream@npm:1.0.0"
   checksum: 10c0/c1924a89686fc035d579cbe856da12306571d5fe7408eeeebe80df7c25c5cc644b8ae102d5cbc0f085d0e105f391d1a48dc0e568520434c5b444ea6c7de2b822
   languageName: node
   linkType: hard
 
 "totalist@npm:^3.0.0":
   version: 3.0.1
-  resolution: "totalist@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftotalist%2F-%2Ftotalist-3.0.1.tgz"
+  resolution: "totalist@npm:3.0.1"
   checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
   languageName: node
   linkType: hard
 
 "tr46@npm:~0.0.3":
   version: 0.0.3
-  resolution: "tr46@npm:0.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftr46%2F-%2Ftr46-0.0.3.tgz"
+  resolution: "tr46@npm:0.0.3"
   checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
   languageName: node
   linkType: hard
 
 "tree-kill@npm:^1.2.2":
   version: 1.2.2
-  resolution: "tree-kill@npm:1.2.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftree-kill%2F-%2Ftree-kill-1.2.2.tgz"
+  resolution: "tree-kill@npm:1.2.2"
   bin:
     tree-kill: cli.js
   checksum: 10c0/7b1b7c7f17608a8f8d20a162e7957ac1ef6cd1636db1aba92f4e072dc31818c2ff0efac1e3d91064ede67ed5dc57c565420531a8134090a12ac10cf792ab14d2
@@ -10617,7 +10617,7 @@ __metadata:
 
 "truncate-utf8-bytes@npm:^1.0.0":
   version: 1.0.2
-  resolution: "truncate-utf8-bytes@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftruncate-utf8-bytes%2F-%2Ftruncate-utf8-bytes-1.0.2.tgz"
+  resolution: "truncate-utf8-bytes@npm:1.0.2"
   dependencies:
     utf8-byte-length: "npm:^1.0.1"
   checksum: 10c0/af2b431fc4314f119b551e5fccfad49d4c0ef82e13ba9ca61be6567801195b08e732ce9643542e8ad1b3df44f3df2d7345b3dd34f723954b6bb43a14584d6b3c
@@ -10626,7 +10626,7 @@ __metadata:
 
 "ts-node-dev@npm:^2.0.0":
   version: 2.0.0
-  resolution: "ts-node-dev@npm:2.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fts-node-dev%2F-%2Fts-node-dev-2.0.0.tgz"
+  resolution: "ts-node-dev@npm:2.0.0"
   dependencies:
     chokidar: "npm:^3.5.1"
     dynamic-dedupe: "npm:^0.3.0"
@@ -10653,7 +10653,7 @@ __metadata:
 
 "ts-node@npm:^10.4.0, ts-node@npm:^10.9.2":
   version: 10.9.2
-  resolution: "ts-node@npm:10.9.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fts-node%2F-%2Fts-node-10.9.2.tgz"
+  resolution: "ts-node@npm:10.9.2"
   dependencies:
     "@cspotcode/source-map-support": "npm:^0.8.0"
     "@tsconfig/node10": "npm:^1.0.7"
@@ -10691,7 +10691,7 @@ __metadata:
 
 "tsconfig@npm:^7.0.0":
   version: 7.0.0
-  resolution: "tsconfig@npm:7.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftsconfig%2F-%2Ftsconfig-7.0.0.tgz"
+  resolution: "tsconfig@npm:7.0.0"
   dependencies:
     "@types/strip-bom": "npm:^3.0.0"
     "@types/strip-json-comments": "npm:0.0.30"
@@ -10703,70 +10703,70 @@ __metadata:
 
 "tslib@npm:^1.9.0":
   version: 1.14.1
-  resolution: "tslib@npm:1.14.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftslib%2F-%2Ftslib-1.14.1.tgz"
+  resolution: "tslib@npm:1.14.1"
   checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
   languageName: node
   linkType: hard
 
 "tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.8.1":
   version: 2.8.1
-  resolution: "tslib@npm:2.8.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftslib%2F-%2Ftslib-2.8.1.tgz"
+  resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
 "tsscmp@npm:1.0.6":
   version: 1.0.6
-  resolution: "tsscmp@npm:1.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftsscmp%2F-%2Ftsscmp-1.0.6.tgz"
+  resolution: "tsscmp@npm:1.0.6"
   checksum: 10c0/2f79a9455e7e3e8071995f98cdf3487ccfc91b760bec21a9abb4d90519557eafaa37246e87c92fa8bf3fef8fd30cfd0cc3c4212bb929baa9fb62494bfa4d24b2
   languageName: node
   linkType: hard
 
 "type-detect@npm:^4.0.0":
   version: 4.1.0
-  resolution: "type-detect@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-detect%2F-%2Ftype-detect-4.1.0.tgz"
+  resolution: "type-detect@npm:4.1.0"
   checksum: 10c0/df8157ca3f5d311edc22885abc134e18ff8ffbc93d6a9848af5b682730ca6a5a44499259750197250479c5331a8a75b5537529df5ec410622041650a7f293e2a
   languageName: node
   linkType: hard
 
 "type-fest@npm:^0.21.3":
   version: 0.21.3
-  resolution: "type-fest@npm:0.21.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-fest%2F-%2Ftype-fest-0.21.3.tgz"
+  resolution: "type-fest@npm:0.21.3"
   checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
   languageName: node
   linkType: hard
 
 "type-fest@npm:^1.0.2":
   version: 1.4.0
-  resolution: "type-fest@npm:1.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-fest%2F-%2Ftype-fest-1.4.0.tgz"
+  resolution: "type-fest@npm:1.4.0"
   checksum: 10c0/a3c0f4ee28ff6ddf800d769eafafcdeab32efa38763c1a1b8daeae681920f6e345d7920bf277245235561d8117dab765cb5f829c76b713b4c9de0998a5397141
   languageName: node
   linkType: hard
 
 "type-fest@npm:^2.5.1":
   version: 2.19.0
-  resolution: "type-fest@npm:2.19.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-fest%2F-%2Ftype-fest-2.19.0.tgz"
+  resolution: "type-fest@npm:2.19.0"
   checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
   languageName: node
   linkType: hard
 
 "type-fest@npm:^3.0.0":
   version: 3.13.1
-  resolution: "type-fest@npm:3.13.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-fest%2F-%2Ftype-fest-3.13.1.tgz"
+  resolution: "type-fest@npm:3.13.1"
   checksum: 10c0/547d22186f73a8c04590b70dcf63baff390078c75ea8acd366bbd510fd0646e348bd1970e47ecf795b7cff0b41d26e9c475c1fedd6ef5c45c82075fbf916b629
   languageName: node
   linkType: hard
 
 "type-fest@npm:^4.18.2, type-fest@npm:^4.21.0, type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
   version: 4.41.0
-  resolution: "type-fest@npm:4.41.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-fest%2F-%2Ftype-fest-4.41.0.tgz"
+  resolution: "type-fest@npm:4.41.0"
   checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
   languageName: node
   linkType: hard
 
 "type-is@npm:~1.6.18":
   version: 1.6.18
-  resolution: "type-is@npm:1.6.18::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-is%2F-%2Ftype-is-1.6.18.tgz"
+  resolution: "type-is@npm:1.6.18"
   dependencies:
     media-typer: "npm:0.3.0"
     mime-types: "npm:~2.1.24"
@@ -10776,14 +10776,14 @@ __metadata:
 
 "type-level-regexp@npm:~0.1.17":
   version: 0.1.17
-  resolution: "type-level-regexp@npm:0.1.17::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftype-level-regexp%2F-%2Ftype-level-regexp-0.1.17.tgz"
+  resolution: "type-level-regexp@npm:0.1.17"
   checksum: 10c0/54798f83464cb5ce04246c9c4739ec471c526aaa7690679fddbce05b689b99403de709f3fcb494555d4276b46c606435a95855e52535602f63378ab8b38010d5
   languageName: node
   linkType: hard
 
 "typescript@npm:^5.9.3":
   version: 5.9.3
-  resolution: "typescript@npm:5.9.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ftypescript%2F-%2Ftypescript-5.9.3.tgz"
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
@@ -10793,7 +10793,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3%3A%3A__archiveUrl=https%253A%252F%252Fpackages.atlassian.com%252Fapi%252Fnpm%252Fnpm-remote%252Ftypescript%252F-%252Ftypescript-5.9.3.tgz#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
@@ -10803,14 +10803,14 @@ __metadata:
 
 "ufo@npm:^1.5.4, ufo@npm:^1.6.1":
   version: 1.6.3
-  resolution: "ufo@npm:1.6.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fufo%2F-%2Fufo-1.6.3.tgz"
+  resolution: "ufo@npm:1.6.3"
   checksum: 10c0/bf0e4ebff99e54da1b9c7182ac2f40475988b41faa881d579bc97bc2a0509672107b0a0e94c4b8d31a0ab8c4bf07f4aa0b469ac6da8536d56bda5b085ea2e953
   languageName: node
   linkType: hard
 
 "uglify-js@npm:^3.1.4":
   version: 3.19.3
-  resolution: "uglify-js@npm:3.19.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fuglify-js%2F-%2Fuglify-js-3.19.3.tgz"
+  resolution: "uglify-js@npm:3.19.3"
   bin:
     uglifyjs: bin/uglifyjs
   checksum: 10c0/83b0a90eca35f778e07cad9622b80c448b6aad457c9ff8e568afed978212b42930a95f9e1be943a1ffa4258a3340fbb899f41461131c05bb1d0a9c303aed8479
@@ -10819,7 +10819,7 @@ __metadata:
 
 "uid-safe@npm:2.1.5, uid-safe@npm:~2.1.5":
   version: 2.1.5
-  resolution: "uid-safe@npm:2.1.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fuid-safe%2F-%2Fuid-safe-2.1.5.tgz"
+  resolution: "uid-safe@npm:2.1.5"
   dependencies:
     random-bytes: "npm:~1.0.0"
   checksum: 10c0/ec96862e859fd12175f3da7fda9d1359a2cf412fd521e10837cbdc6d554774079ce252f366981df9401283841c8924782f6dbee8f82a3a81f805ed8a8584595d
@@ -10828,35 +10828,35 @@ __metadata:
 
 "undici-types@npm:~6.21.0":
   version: 6.21.0
-  resolution: "undici-types@npm:6.21.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fundici-types%2F-%2Fundici-types-6.21.0.tgz"
+  resolution: "undici-types@npm:6.21.0"
   checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 
 "undici-types@npm:~7.16.0":
   version: 7.16.0
-  resolution: "undici-types@npm:7.16.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fundici-types%2F-%2Fundici-types-7.16.0.tgz"
+  resolution: "undici-types@npm:7.16.0"
   checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
   languageName: node
   linkType: hard
 
 "unicorn-magic@npm:^0.1.0":
   version: 0.1.0
-  resolution: "unicorn-magic@npm:0.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funicorn-magic%2F-%2Funicorn-magic-0.1.0.tgz"
+  resolution: "unicorn-magic@npm:0.1.0"
   checksum: 10c0/e4ed0de05b0a05e735c7d8a2930881e5efcfc3ec897204d5d33e7e6247f4c31eac92e383a15d9a6bccb7319b4271ee4bea946e211bf14951fec6ff2cbbb66a92
   languageName: node
   linkType: hard
 
 "unicorn-magic@npm:^0.3.0":
   version: 0.3.0
-  resolution: "unicorn-magic@npm:0.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funicorn-magic%2F-%2Funicorn-magic-0.3.0.tgz"
+  resolution: "unicorn-magic@npm:0.3.0"
   checksum: 10c0/0a32a997d6c15f1c2a077a15b1c4ca6f268d574cf5b8975e778bb98e6f8db4ef4e86dfcae4e158cd4c7e38fb4dd383b93b13eefddc7f178dea13d3ac8a603271
   languageName: node
   linkType: hard
 
 "unique-filename@npm:^5.0.0":
   version: 5.0.0
-  resolution: "unique-filename@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funique-filename%2F-%2Funique-filename-5.0.0.tgz"
+  resolution: "unique-filename@npm:5.0.0"
   dependencies:
     unique-slug: "npm:^6.0.0"
   checksum: 10c0/afb897e9cf4c2fb622ea716f7c2bb462001928fc5f437972213afdf1cc32101a230c0f1e9d96fc91ee5185eca0f2feb34127145874975f347be52eb91d6ccc2c
@@ -10865,7 +10865,7 @@ __metadata:
 
 "unique-slug@npm:^6.0.0":
   version: 6.0.0
-  resolution: "unique-slug@npm:6.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funique-slug%2F-%2Funique-slug-6.0.0.tgz"
+  resolution: "unique-slug@npm:6.0.0"
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/da7ade4cb04eb33ad0499861f82fe95ce9c7c878b7139dc54d140ecfb6a6541c18a5c8dac16188b8b379fe62c0c1f1b710814baac910cde5f4fec06212126c6a
@@ -10874,28 +10874,28 @@ __metadata:
 
 "universalify@npm:^0.1.0":
   version: 0.1.2
-  resolution: "universalify@npm:0.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funiversalify%2F-%2Funiversalify-0.1.2.tgz"
+  resolution: "universalify@npm:0.1.2"
   checksum: 10c0/e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045
   languageName: node
   linkType: hard
 
 "universalify@npm:^2.0.0":
   version: 2.0.1
-  resolution: "universalify@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funiversalify%2F-%2Funiversalify-2.0.1.tgz"
+  resolution: "universalify@npm:2.0.1"
   checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
   languageName: node
   linkType: hard
 
 "unpipe@npm:~1.0.0":
   version: 1.0.0
-  resolution: "unpipe@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funpipe%2F-%2Funpipe-1.0.0.tgz"
+  resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
   languageName: node
   linkType: hard
 
 "unplugin@npm:^2.0.0":
   version: 2.3.11
-  resolution: "unplugin@npm:2.3.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funplugin%2F-%2Funplugin-2.3.11.tgz"
+  resolution: "unplugin@npm:2.3.11"
   dependencies:
     "@jridgewell/remapping": "npm:^2.3.5"
     acorn: "npm:^8.15.0"
@@ -10907,7 +10907,7 @@ __metadata:
 
 "update-browserslist-db@npm:^1.2.0":
   version: 1.2.3
-  resolution: "update-browserslist-db@npm:1.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fupdate-browserslist-db%2F-%2Fupdate-browserslist-db-1.2.3.tgz"
+  resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -10921,7 +10921,7 @@ __metadata:
 
 "update-notifier@npm:^7.3.1":
   version: 7.3.1
-  resolution: "update-notifier@npm:7.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fupdate-notifier%2F-%2Fupdate-notifier-7.3.1.tgz"
+  resolution: "update-notifier@npm:7.3.1"
   dependencies:
     boxen: "npm:^8.0.1"
     chalk: "npm:^5.3.0"
@@ -10939,7 +10939,7 @@ __metadata:
 
 "upload-files-express@npm:^0.4.0":
   version: 0.4.0
-  resolution: "upload-files-express@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fupload-files-express%2F-%2Fupload-files-express-0.4.0.tgz"
+  resolution: "upload-files-express@npm:0.4.0"
   dependencies:
     formidable: "npm:^2.0.1"
   checksum: 10c0/94accc0047d5cff1378c305a6e49478b60f1cfc7c46ac13935cf4c527959103d89ba878684098a03c29abd6e98956d29754535b9d9d75b1f6a6c32f3123681b9
@@ -10948,28 +10948,28 @@ __metadata:
 
 "utf8-byte-length@npm:^1.0.1":
   version: 1.0.5
-  resolution: "utf8-byte-length@npm:1.0.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Futf8-byte-length%2F-%2Futf8-byte-length-1.0.5.tgz"
+  resolution: "utf8-byte-length@npm:1.0.5"
   checksum: 10c0/e69bda3299608f4cc75976da9fb74ac94801a58b9ca29fdad03a20ec952e7477d7f226c12716b5f36bd4cff8151d1d152d02ee1df3752f017d4b2c725ce3e47a
   languageName: node
   linkType: hard
 
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2":
   version: 1.0.2
-  resolution: "util-deprecate@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Futil-deprecate%2F-%2Futil-deprecate-1.0.2.tgz"
+  resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
   languageName: node
   linkType: hard
 
 "utils-merge@npm:1.0.1":
   version: 1.0.1
-  resolution: "utils-merge@npm:1.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Futils-merge%2F-%2Futils-merge-1.0.1.tgz"
+  resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
   languageName: node
   linkType: hard
 
 "uuid@npm:^11.0.2":
   version: 11.1.0
-  resolution: "uuid@npm:11.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fuuid%2F-%2Fuuid-11.1.0.tgz"
+  resolution: "uuid@npm:11.1.0"
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
@@ -10978,7 +10978,7 @@ __metadata:
 
 "uuid@npm:^8.0.0":
   version: 8.3.2
-  resolution: "uuid@npm:8.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fuuid%2F-%2Fuuid-8.3.2.tgz"
+  resolution: "uuid@npm:8.3.2"
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
@@ -10987,7 +10987,7 @@ __metadata:
 
 "uuid@npm:^9.0.0, uuid@npm:^9.0.1":
   version: 9.0.1
-  resolution: "uuid@npm:9.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fuuid%2F-%2Fuuid-9.0.1.tgz"
+  resolution: "uuid@npm:9.0.1"
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
@@ -10996,14 +10996,14 @@ __metadata:
 
 "v8-compile-cache-lib@npm:^3.0.1":
   version: 3.0.1
-  resolution: "v8-compile-cache-lib@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fv8-compile-cache-lib%2F-%2Fv8-compile-cache-lib-3.0.1.tgz"
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
   checksum: 10c0/bdc36fb8095d3b41df197f5fb6f11e3a26adf4059df3213e3baa93810d8f0cc76f9a74aaefc18b73e91fe7e19154ed6f134eda6fded2e0f1c8d2272ed2d2d391
   languageName: node
   linkType: hard
 
 "validate-npm-package-license@npm:^3.0.4":
   version: 3.0.4
-  resolution: "validate-npm-package-license@npm:3.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fvalidate-npm-package-license%2F-%2Fvalidate-npm-package-license-3.0.4.tgz"
+  resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
@@ -11013,21 +11013,21 @@ __metadata:
 
 "validate-npm-package-name@npm:^5.0.0":
   version: 5.0.1
-  resolution: "validate-npm-package-name@npm:5.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fvalidate-npm-package-name%2F-%2Fvalidate-npm-package-name-5.0.1.tgz"
+  resolution: "validate-npm-package-name@npm:5.0.1"
   checksum: 10c0/903e738f7387404bb72f7ac34e45d7010c877abd2803dc2d614612527927a40a6d024420033132e667b1bade94544b8a1f65c9431a4eb30d0ce0d80093cd1f74
   languageName: node
   linkType: hard
 
 "vary@npm:^1, vary@npm:~1.1.2":
   version: 1.1.2
-  resolution: "vary@npm:1.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fvary%2F-%2Fvary-1.1.2.tgz"
+  resolution: "vary@npm:1.1.2"
   checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
   languageName: node
   linkType: hard
 
 "vite@npm:^6.0.0 || ^7.0.0":
   version: 7.3.1
-  resolution: "vite@npm:7.3.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fvite%2F-%2Fvite-7.3.1.tgz"
+  resolution: "vite@npm:7.3.1"
   dependencies:
     esbuild: "npm:^0.27.0"
     fdir: "npm:^6.5.0"
@@ -11082,7 +11082,7 @@ __metadata:
 
 "vitest@npm:4.0.6":
   version: 4.0.6
-  resolution: "vitest@npm:4.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fvitest%2F-%2Fvitest-4.0.6.tgz"
+  resolution: "vitest@npm:4.0.6"
   dependencies:
     "@vitest/expect": "npm:4.0.6"
     "@vitest/mocker": "npm:4.0.6"
@@ -11141,14 +11141,14 @@ __metadata:
 
 "void-elements@npm:^3.1.0":
   version: 3.1.0
-  resolution: "void-elements@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fvoid-elements%2F-%2Fvoid-elements-3.1.0.tgz"
+  resolution: "void-elements@npm:3.1.0"
   checksum: 10c0/0b8686f9f9aa44012e9bd5eabf287ae0cde409b9a2854c5a2335cb83920c957668ac5876e3f0d158dd424744ac411a7270e64128556b451ed3bec875ef18534d
   languageName: node
   linkType: hard
 
 "walk@npm:2.3.15":
   version: 2.3.15
-  resolution: "walk@npm:2.3.15::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwalk%2F-%2Fwalk-2.3.15.tgz"
+  resolution: "walk@npm:2.3.15"
   dependencies:
     foreachasync: "npm:^3.0.0"
   checksum: 10c0/c390221ff6fdb8e95f9b03d90fa9980edc2c01ce9efac44c0ade2036ee2823bf2bc9abfae388bdf64ab59e9262610e7cf6634ad54acac018e62621b85edad2cf
@@ -11157,21 +11157,21 @@ __metadata:
 
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwebidl-conversions%2F-%2Fwebidl-conversions-3.0.1.tgz"
+  resolution: "webidl-conversions@npm:3.0.1"
   checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
   languageName: node
   linkType: hard
 
 "webpack-virtual-modules@npm:^0.6.2":
   version: 0.6.2
-  resolution: "webpack-virtual-modules@npm:0.6.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwebpack-virtual-modules%2F-%2Fwebpack-virtual-modules-0.6.2.tgz"
+  resolution: "webpack-virtual-modules@npm:0.6.2"
   checksum: 10c0/5ffbddf0e84bf1562ff86cf6fcf039c74edf09d78358a6904a09bbd4484e8bb6812dc385fe14330b715031892dcd8423f7a88278b57c9f5002c84c2860179add
   languageName: node
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1":
   version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwebsocket-driver%2F-%2Fwebsocket-driver-0.7.4.tgz"
+  resolution: "websocket-driver@npm:0.7.4"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
@@ -11182,14 +11182,14 @@ __metadata:
 
 "websocket-extensions@npm:>=0.1.1":
   version: 0.1.4
-  resolution: "websocket-extensions@npm:0.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwebsocket-extensions%2F-%2Fwebsocket-extensions-0.1.4.tgz"
+  resolution: "websocket-extensions@npm:0.1.4"
   checksum: 10c0/bbc8c233388a0eb8a40786ee2e30d35935cacbfe26ab188b3e020987e85d519c2009fe07cfc37b7f718b85afdba7e54654c9153e6697301f72561bfe429177e0
   languageName: node
   linkType: hard
 
 "whatwg-url@npm:^5.0.0":
   version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwhatwg-url%2F-%2Fwhatwg-url-5.0.0.tgz"
+  resolution: "whatwg-url@npm:5.0.0"
   dependencies:
     tr46: "npm:~0.0.3"
     webidl-conversions: "npm:^3.0.0"
@@ -11199,14 +11199,14 @@ __metadata:
 
 "when-exit@npm:^2.1.4":
   version: 2.1.5
-  resolution: "when-exit@npm:2.1.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwhen-exit%2F-%2Fwhen-exit-2.1.5.tgz"
+  resolution: "when-exit@npm:2.1.5"
   checksum: 10c0/7db41b28c98456b784c25780ca327653f233c6eb7b25d4ce251d04519828cbd609fb6d10548caf9031d4d6fab2999d6f6911c32e1731efab24c93a522573470d
   languageName: node
   linkType: hard
 
 "which@npm:^2.0.1":
   version: 2.0.2
-  resolution: "which@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwhich%2F-%2Fwhich-2.0.2.tgz"
+  resolution: "which@npm:2.0.2"
   dependencies:
     isexe: "npm:^2.0.0"
   bin:
@@ -11217,7 +11217,7 @@ __metadata:
 
 "which@npm:^6.0.0":
   version: 6.0.0
-  resolution: "which@npm:6.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwhich%2F-%2Fwhich-6.0.0.tgz"
+  resolution: "which@npm:6.0.0"
   dependencies:
     isexe: "npm:^3.1.1"
   bin:
@@ -11228,7 +11228,7 @@ __metadata:
 
 "why-is-node-running@npm:^2.3.0":
   version: 2.3.0
-  resolution: "why-is-node-running@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwhy-is-node-running%2F-%2Fwhy-is-node-running-2.3.0.tgz"
+  resolution: "why-is-node-running@npm:2.3.0"
   dependencies:
     siginfo: "npm:^2.0.0"
     stackback: "npm:0.0.2"
@@ -11240,7 +11240,7 @@ __metadata:
 
 "wide-align@npm:^1.1.5":
   version: 1.1.5
-  resolution: "wide-align@npm:1.1.5::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwide-align%2F-%2Fwide-align-1.1.5.tgz"
+  resolution: "wide-align@npm:1.1.5"
   dependencies:
     string-width: "npm:^1.0.2 || 2 || 3 || 4"
   checksum: 10c0/1d9c2a3e36dfb09832f38e2e699c367ef190f96b82c71f809bc0822c306f5379df87bab47bed27ea99106d86447e50eb972d3c516c2f95782807a9d082fbea95
@@ -11249,7 +11249,7 @@ __metadata:
 
 "widest-line@npm:^5.0.0":
   version: 5.0.0
-  resolution: "widest-line@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwidest-line%2F-%2Fwidest-line-5.0.0.tgz"
+  resolution: "widest-line@npm:5.0.0"
   dependencies:
     string-width: "npm:^7.0.0"
   checksum: 10c0/6bd6cca8cda502ef50e05353fd25de0df8c704ffc43ada7e0a9cf9a5d4f4e12520485d80e0b77cec8a21f6c3909042fcf732aa9281e5dbb98cc9384a138b2578
@@ -11258,7 +11258,7 @@ __metadata:
 
 "with@npm:^7.0.0":
   version: 7.0.2
-  resolution: "with@npm:7.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwith%2F-%2Fwith-7.0.2.tgz"
+  resolution: "with@npm:7.0.2"
   dependencies:
     "@babel/parser": "npm:^7.9.6"
     "@babel/types": "npm:^7.9.6"
@@ -11270,14 +11270,14 @@ __metadata:
 
 "wordwrap@npm:^1.0.0":
   version: 1.0.0
-  resolution: "wordwrap@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwordwrap%2F-%2Fwordwrap-1.0.0.tgz"
+  resolution: "wordwrap@npm:1.0.0"
   checksum: 10c0/7ed2e44f3c33c5c3e3771134d2b0aee4314c9e49c749e37f464bf69f2bcdf0cbf9419ca638098e2717cff4875c47f56a007532f6111c3319f557a2ca91278e92
   languageName: node
   linkType: hard
 
 "wrap-ansi@npm:^3.0.1":
   version: 3.0.1
-  resolution: "wrap-ansi@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwrap-ansi%2F-%2Fwrap-ansi-3.0.1.tgz"
+  resolution: "wrap-ansi@npm:3.0.1"
   dependencies:
     string-width: "npm:^2.1.1"
     strip-ansi: "npm:^4.0.0"
@@ -11287,7 +11287,7 @@ __metadata:
 
 "wrap-ansi@npm:^6.2.0":
   version: 6.2.0
-  resolution: "wrap-ansi@npm:6.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwrap-ansi%2F-%2Fwrap-ansi-6.2.0.tgz"
+  resolution: "wrap-ansi@npm:6.2.0"
   dependencies:
     ansi-styles: "npm:^4.0.0"
     string-width: "npm:^4.1.0"
@@ -11298,7 +11298,7 @@ __metadata:
 
 "wrap-ansi@npm:^7.0.0":
   version: 7.0.0
-  resolution: "wrap-ansi@npm:7.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwrap-ansi%2F-%2Fwrap-ansi-7.0.0.tgz"
+  resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
     ansi-styles: "npm:^4.0.0"
     string-width: "npm:^4.1.0"
@@ -11309,7 +11309,7 @@ __metadata:
 
 "wrap-ansi@npm:^9.0.0":
   version: 9.0.2
-  resolution: "wrap-ansi@npm:9.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwrap-ansi%2F-%2Fwrap-ansi-9.0.2.tgz"
+  resolution: "wrap-ansi@npm:9.0.2"
   dependencies:
     ansi-styles: "npm:^6.2.1"
     string-width: "npm:^7.0.0"
@@ -11320,14 +11320,14 @@ __metadata:
 
 "wrappy@npm:1":
   version: 1.0.2
-  resolution: "wrappy@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwrappy%2F-%2Fwrappy-1.0.2.tgz"
+  resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
   languageName: node
   linkType: hard
 
 "ws@npm:~8.18.3":
   version: 8.18.3
-  resolution: "ws@npm:8.18.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fws%2F-%2Fws-8.18.3.tgz"
+  resolution: "ws@npm:8.18.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -11342,7 +11342,7 @@ __metadata:
 
 "wsl-utils@npm:^0.1.0":
   version: 0.1.0
-  resolution: "wsl-utils@npm:0.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fwsl-utils%2F-%2Fwsl-utils-0.1.0.tgz"
+  resolution: "wsl-utils@npm:0.1.0"
   dependencies:
     is-wsl: "npm:^3.1.0"
   checksum: 10c0/44318f3585eb97be994fc21a20ddab2649feaf1fbe893f1f866d936eea3d5f8c743bec6dc02e49fbdd3c0e69e9b36f449d90a0b165a4f47dd089747af4cf2377
@@ -11351,63 +11351,63 @@ __metadata:
 
 "xdg-basedir@npm:^5.1.0":
   version: 5.1.0
-  resolution: "xdg-basedir@npm:5.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fxdg-basedir%2F-%2Fxdg-basedir-5.1.0.tgz"
+  resolution: "xdg-basedir@npm:5.1.0"
   checksum: 10c0/c88efabc71ffd996ba9ad8923a8cc1c7c020a03e2c59f0ffa72e06be9e724ad2a0fccef488757bc6ed3d8849d753dd25082d1035d95cb179e79eae4d034d0b80
   languageName: node
   linkType: hard
 
 "xtend@npm:^4.0.0":
   version: 4.0.2
-  resolution: "xtend@npm:4.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fxtend%2F-%2Fxtend-4.0.2.tgz"
+  resolution: "xtend@npm:4.0.2"
   checksum: 10c0/366ae4783eec6100f8a02dff02ac907bf29f9a00b82ac0264b4d8b832ead18306797e283cf19de776538babfdcb2101375ec5646b59f08c52128ac4ab812ed0e
   languageName: node
   linkType: hard
 
 "y18n@npm:^5.0.5":
   version: 5.0.8
-  resolution: "y18n@npm:5.0.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fy18n%2F-%2Fy18n-5.0.8.tgz"
+  resolution: "y18n@npm:5.0.8"
   checksum: 10c0/4df2842c36e468590c3691c894bc9cdbac41f520566e76e24f59401ba7d8b4811eb1e34524d57e54bc6d864bcb66baab7ffd9ca42bf1eda596618f9162b91249
   languageName: node
   linkType: hard
 
 "yallist@npm:^3.0.2":
   version: 3.1.1
-  resolution: "yallist@npm:3.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyallist%2F-%2Fyallist-3.1.1.tgz"
+  resolution: "yallist@npm:3.1.1"
   checksum: 10c0/c66a5c46bc89af1625476f7f0f2ec3653c1a1791d2f9407cfb4c2ba812a1e1c9941416d71ba9719876530e3340a99925f697142989371b72d93b9ee628afd8c1
   languageName: node
   linkType: hard
 
 "yallist@npm:^4.0.0":
   version: 4.0.0
-  resolution: "yallist@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyallist%2F-%2Fyallist-4.0.0.tgz"
+  resolution: "yallist@npm:4.0.0"
   checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
   languageName: node
   linkType: hard
 
 "yallist@npm:^5.0.0":
   version: 5.0.0
-  resolution: "yallist@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyallist%2F-%2Fyallist-5.0.0.tgz"
+  resolution: "yallist@npm:5.0.0"
   checksum: 10c0/a499c81ce6d4a1d260d4ea0f6d49ab4da09681e32c3f0472dee16667ed69d01dae63a3b81745a24bd78476ec4fcf856114cb4896ace738e01da34b2c42235416
   languageName: node
   linkType: hard
 
 "yargs-parser@npm:^21.1.1":
   version: 21.1.1
-  resolution: "yargs-parser@npm:21.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyargs-parser%2F-%2Fyargs-parser-21.1.1.tgz"
+  resolution: "yargs-parser@npm:21.1.1"
   checksum: 10c0/f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2
   languageName: node
   linkType: hard
 
 "yargs-parser@npm:^22.0.0":
   version: 22.0.0
-  resolution: "yargs-parser@npm:22.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyargs-parser%2F-%2Fyargs-parser-22.0.0.tgz"
+  resolution: "yargs-parser@npm:22.0.0"
   checksum: 10c0/cb7ef81759c4271cb1d96b9351dbbc9a9ce35d3e1122d2b739bf6c432603824fa02c67cc12dcef6ea80283379d63495686e8f41cc7b06c6576e792aba4d33e1c
   languageName: node
   linkType: hard
 
 "yargs@npm:^17.7.2":
   version: 17.7.2
-  resolution: "yargs@npm:17.7.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyargs%2F-%2Fyargs-17.7.2.tgz"
+  resolution: "yargs@npm:17.7.2"
   dependencies:
     cliui: "npm:^8.0.1"
     escalade: "npm:^3.1.1"
@@ -11422,7 +11422,7 @@ __metadata:
 
 "yargs@npm:^18.0.0":
   version: 18.0.0
-  resolution: "yargs@npm:18.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyargs%2F-%2Fyargs-18.0.0.tgz"
+  resolution: "yargs@npm:18.0.0"
   dependencies:
     cliui: "npm:^9.0.1"
     escalade: "npm:^3.1.1"
@@ -11436,28 +11436,28 @@ __metadata:
 
 "yn@npm:3.1.1":
   version: 3.1.1
-  resolution: "yn@npm:3.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyn%2F-%2Fyn-3.1.1.tgz"
+  resolution: "yn@npm:3.1.1"
   checksum: 10c0/0732468dd7622ed8a274f640f191f3eaf1f39d5349a1b72836df484998d7d9807fbea094e2f5486d6b0cd2414aad5775972df0e68f8604db89a239f0f4bf7443
   languageName: node
   linkType: hard
 
 "yocto-queue@npm:^0.1.0":
   version: 0.1.0
-  resolution: "yocto-queue@npm:0.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyocto-queue%2F-%2Fyocto-queue-0.1.0.tgz"
+  resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
 
 "yoctocolors-cjs@npm:^2.1.3":
   version: 2.1.3
-  resolution: "yoctocolors-cjs@npm:2.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyoctocolors-cjs%2F-%2Fyoctocolors-cjs-2.1.3.tgz"
+  resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
   languageName: node
   linkType: hard
 
 "yoctocolors@npm:^2.1.1":
   version: 2.1.2
-  resolution: "yoctocolors@npm:2.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fyoctocolors%2F-%2Fyoctocolors-2.1.2.tgz"
+  resolution: "yoctocolors@npm:2.1.2"
   checksum: 10c0/b220f30f53ebc2167330c3adc86a3c7f158bcba0236f6c67e25644c3188e2571a6014ffc1321943bb619460259d3d27eb4c9cc58c2d884c1b195805883ec7066
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.5.5":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Fruntime%2F-%2Fruntime-7.29.7.tgz"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/template@npm:7.28.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40babel%2Ftemplate%2F-%2Ftemplate-7.28.6.tgz"
@@ -226,6 +233,239 @@ __metadata:
   version: 1.0.2
   resolution: "@bcoe/v8-coverage@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40bcoe%2Fv8-coverage%2F-%2Fv8-coverage-1.0.2.tgz"
   checksum: 10c0/1eb1dc93cc17fb7abdcef21a6e7b867d6aa99a7ec88ec8207402b23d9083ab22a8011213f04b2cf26d535f1d22dc26139b7929e6c2134c254bd1e14ba5e678c3
+  languageName: node
+  linkType: hard
+
+"@changesets/apply-release-plan@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "@changesets/apply-release-plan@npm:7.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fapply-release-plan%2F-%2Fapply-release-plan-7.1.1.tgz"
+  dependencies:
+    "@changesets/config": "npm:^3.1.4"
+    "@changesets/get-version-range-type": "npm:^0.4.0"
+    "@changesets/git": "npm:^3.0.4"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    detect-indent: "npm:^6.0.0"
+    fs-extra: "npm:^7.0.1"
+    lodash.startcase: "npm:^4.4.0"
+    outdent: "npm:^0.5.0"
+    prettier: "npm:^2.7.1"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.5.3"
+  checksum: 10c0/27de184e74e8e48b43fca1f73e7c7a2887b0cdacfe7ba9c09cdc4547dff0de1587bed5fe2d5ec0a3754fa422f6b8a528e0ac452c22ac7a6ae5211f5ac089bfb2
+  languageName: node
+  linkType: hard
+
+"@changesets/assemble-release-plan@npm:^6.0.10":
+  version: 6.0.10
+  resolution: "@changesets/assemble-release-plan@npm:6.0.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fassemble-release-plan%2F-%2Fassemble-release-plan-6.0.10.tgz"
+  dependencies:
+    "@changesets/errors": "npm:^0.2.0"
+    "@changesets/get-dependents-graph": "npm:^2.1.4"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    semver: "npm:^7.5.3"
+  checksum: 10c0/a0ea336a5f19f8d0a97b684983bcd9c3bb8d6881b7b6abd5b482b301795ae4600924c188982f5f98dc48ac88e94a063b66ab72659041eb2623ade3e35f05d555
+  languageName: node
+  linkType: hard
+
+"@changesets/changelog-git@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@changesets/changelog-git@npm:0.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fchangelog-git%2F-%2Fchangelog-git-0.2.1.tgz"
+  dependencies:
+    "@changesets/types": "npm:^6.1.0"
+  checksum: 10c0/6a6fb315ffb2266fcb8f32ae9a60ccdb5436e52350a2f53beacf9822d3355f9052aba5001a718e12af472b4a8fabd69b408d0b11c02ac909ba7a183d27a9f7fd
+  languageName: node
+  linkType: hard
+
+"@changesets/cli@npm:^2.31.1":
+  version: 2.31.1
+  resolution: "@changesets/cli@npm:2.31.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fcli%2F-%2Fcli-2.31.1.tgz"
+  dependencies:
+    "@changesets/apply-release-plan": "npm:^7.1.1"
+    "@changesets/assemble-release-plan": "npm:^6.0.10"
+    "@changesets/changelog-git": "npm:^0.2.1"
+    "@changesets/config": "npm:^3.1.4"
+    "@changesets/errors": "npm:^0.2.0"
+    "@changesets/get-dependents-graph": "npm:^2.1.4"
+    "@changesets/get-release-plan": "npm:^4.0.16"
+    "@changesets/git": "npm:^3.0.4"
+    "@changesets/logger": "npm:^0.1.1"
+    "@changesets/pre": "npm:^2.0.2"
+    "@changesets/read": "npm:^0.6.7"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@changesets/write": "npm:^0.4.0"
+    "@inquirer/external-editor": "npm:^1.0.2"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    ansi-colors: "npm:^4.1.3"
+    enquirer: "npm:^2.4.1"
+    fs-extra: "npm:^7.0.1"
+    mri: "npm:^1.2.0"
+    package-manager-detector: "npm:^0.2.0"
+    picocolors: "npm:^1.1.0"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.5.3"
+    spawndamnit: "npm:^3.0.1"
+    term-size: "npm:^2.1.0"
+  bin:
+    changeset: bin.js
+  checksum: 10c0/375789e85def0bb303ada45d5085c92765010e6b88b8252eb459346ac8a94eba098c9cb8ad416241757796a8828c417fc9e0a23011bd3a74ce33eef013d8311a
+  languageName: node
+  linkType: hard
+
+"@changesets/config@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@changesets/config@npm:3.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fconfig%2F-%2Fconfig-3.1.4.tgz"
+  dependencies:
+    "@changesets/errors": "npm:^0.2.0"
+    "@changesets/get-dependents-graph": "npm:^2.1.4"
+    "@changesets/logger": "npm:^0.1.1"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    fs-extra: "npm:^7.0.1"
+    micromatch: "npm:^4.0.8"
+  checksum: 10c0/1c0e7975aa719e2c87dfda3f5a1eb81b9f4852cdfb5b5c9d181fa2f8f485e92370b3bdfdb6f666432207dd75a3f79fa8fffe7847d48fb11308acb5ecf327bc12
+  languageName: node
+  linkType: hard
+
+"@changesets/errors@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@changesets/errors@npm:0.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Ferrors%2F-%2Ferrors-0.2.0.tgz"
+  dependencies:
+    extendable-error: "npm:^0.1.5"
+  checksum: 10c0/f2757c752ab04e9733b0dfd7903f1caf873f9e603794c4d9ea2294af4f937c73d07273c24be864ad0c30b6a98424360d5b96a6eab14f97f3cf2cbfd3763b95c1
+  languageName: node
+  linkType: hard
+
+"@changesets/get-dependents-graph@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@changesets/get-dependents-graph@npm:2.1.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fget-dependents-graph%2F-%2Fget-dependents-graph-2.1.4.tgz"
+  dependencies:
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    picocolors: "npm:^1.1.0"
+    semver: "npm:^7.5.3"
+  checksum: 10c0/37b12ba42f16c458d0b574bcafa0247ff2b9a218686a64c86fc75bccc9ba3982f9c27206542941cf3a0563d9b199f40a830682b45e9fd902536de91344cbd0a2
+  languageName: node
+  linkType: hard
+
+"@changesets/get-release-plan@npm:^4.0.16":
+  version: 4.0.16
+  resolution: "@changesets/get-release-plan@npm:4.0.16::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fget-release-plan%2F-%2Fget-release-plan-4.0.16.tgz"
+  dependencies:
+    "@changesets/assemble-release-plan": "npm:^6.0.10"
+    "@changesets/config": "npm:^3.1.4"
+    "@changesets/pre": "npm:^2.0.2"
+    "@changesets/read": "npm:^0.6.7"
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+  checksum: 10c0/4be4553e13fe331f6d5b2ed98fece21c8d2b38c04a0543f726a0398b7538ef8fd073d712c35ae4540ed4fc6f84f08de6335318bc09dd562b189fb6968d049e95
+  languageName: node
+  linkType: hard
+
+"@changesets/get-version-range-type@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@changesets/get-version-range-type@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fget-version-range-type%2F-%2Fget-version-range-type-0.4.0.tgz"
+  checksum: 10c0/e466208c8383489a383f37958d8b5b9aed38539f9287b47fe155a2e8855973f6960fb1724a1ee33b11580d65e1011059045ee654e8ef51e4783017d8989c9d3f
+  languageName: node
+  linkType: hard
+
+"@changesets/git@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@changesets/git@npm:3.0.4::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fgit%2F-%2Fgit-3.0.4.tgz"
+  dependencies:
+    "@changesets/errors": "npm:^0.2.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    is-subdir: "npm:^1.1.1"
+    micromatch: "npm:^4.0.8"
+    spawndamnit: "npm:^3.0.1"
+  checksum: 10c0/4abbdc1dec6ddc50b6ad927d9eba4f23acd775fdff615415813099befb0cecd1b0f56ceea5e18a5a3cbbb919d68179366074b02a954fbf4016501e5fd125d2b5
+  languageName: node
+  linkType: hard
+
+"@changesets/logger@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@changesets/logger@npm:0.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Flogger%2F-%2Flogger-0.1.1.tgz"
+  dependencies:
+    picocolors: "npm:^1.1.0"
+  checksum: 10c0/a0933b5bd4d99e10730b22612dc1bdfd25b8804c5b48f8cada050bf5c7a89b2ae9a61687f846a5e9e5d379a95b59fef795c8d5d91e49a251f8da2be76133f83f
+  languageName: node
+  linkType: hard
+
+"@changesets/parse@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "@changesets/parse@npm:0.4.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fparse%2F-%2Fparse-0.4.3.tgz"
+  dependencies:
+    "@changesets/types": "npm:^6.1.0"
+    js-yaml: "npm:^4.1.1"
+  checksum: 10c0/4d8488eaf224974ae335fec964dc1dc486abcfa9f96856cf4267c2765b02ed6af1778375ec03d38252ebab9e191aa4a11c5f37a6ad42e907e08290fed2b9690c
+  languageName: node
+  linkType: hard
+
+"@changesets/pre@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@changesets/pre@npm:2.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fpre%2F-%2Fpre-2.0.2.tgz"
+  dependencies:
+    "@changesets/errors": "npm:^0.2.0"
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    fs-extra: "npm:^7.0.1"
+  checksum: 10c0/0af9396d84c47a88d79b757e9db4e3579b6620260f92c243b8349e7fcefca3c2652583f6d215c13115bed5d5cdc30c975f307fd6acbb89d205b1ba2ae403b918
+  languageName: node
+  linkType: hard
+
+"@changesets/read@npm:^0.6.7":
+  version: 0.6.7
+  resolution: "@changesets/read@npm:0.6.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fread%2F-%2Fread-0.6.7.tgz"
+  dependencies:
+    "@changesets/git": "npm:^3.0.4"
+    "@changesets/logger": "npm:^0.1.1"
+    "@changesets/parse": "npm:^0.4.3"
+    "@changesets/types": "npm:^6.1.0"
+    fs-extra: "npm:^7.0.1"
+    p-filter: "npm:^2.1.0"
+    picocolors: "npm:^1.1.0"
+  checksum: 10c0/eebda5f5cea8684b9cb470e74cd5e67043a62ca54452ac88bb1a998bebeee1a2e3a642dc76818155a145863551c65f10f9c4ff85378b0419179fc60049edbbc6
+  languageName: node
+  linkType: hard
+
+"@changesets/should-skip-package@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@changesets/should-skip-package@npm:0.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fshould-skip-package%2F-%2Fshould-skip-package-0.1.2.tgz"
+  dependencies:
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+  checksum: 10c0/484e339e7d6e6950e12bff4eda6e8eccb077c0fbb1f09dd95d2ae948b715226a838c71eaf50cd2d7e0e631ce3bfb1ca93ac752436e6feae5b87aece2e917b440
+  languageName: node
+  linkType: hard
+
+"@changesets/types@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "@changesets/types@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Ftypes%2F-%2Ftypes-4.1.0.tgz"
+  checksum: 10c0/a372ad21f6a1e0d4ce6c19573c1ca269eef1ad53c26751ad9515a24f003e7c49dcd859dbb1fedb6badaf7be956c1559e8798304039e0ec0da2d9a68583f13464
+  languageName: node
+  linkType: hard
+
+"@changesets/types@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@changesets/types@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Ftypes%2F-%2Ftypes-6.1.0.tgz"
+  checksum: 10c0/b4cea3a4465d1eaf0bbd7be1e404aca5a055a61d4cc72aadcb73bbbda1670b4022736b8d3052616cbf1f451afa0637545d077697f4b923236539af9cd5abce6c
+  languageName: node
+  linkType: hard
+
+"@changesets/write@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@changesets/write@npm:0.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40changesets%2Fwrite%2F-%2Fwrite-0.4.0.tgz"
+  dependencies:
+    "@changesets/types": "npm:^6.1.0"
+    fs-extra: "npm:^7.0.1"
+    human-id: "npm:^4.1.1"
+    prettier: "npm:^2.7.1"
+  checksum: 10c0/311f4d0e536d1b5f2d3f9053537d62b2d4cdbd51e1d2767807ac9d1e0f380367f915d2ad370e5c73902d5a54bffd282d53fff5418c8ad31df51751d652bea826
   languageName: node
   linkType: hard
 
@@ -916,7 +1156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/external-editor@npm:^1.0.3":
+"@inquirer/external-editor@npm:^1.0.2, @inquirer/external-editor@npm:^1.0.3":
   version: 1.0.3
   resolution: "@inquirer/external-editor@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40inquirer%2Fexternal-editor%2F-%2Fexternal-editor-1.0.3.tgz"
   dependencies:
@@ -1170,6 +1410,32 @@ __metadata:
   version: 4.4.2
   resolution: "@js-sdsl/ordered-map@npm:4.4.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40js-sdsl%2Fordered-map%2F-%2Fordered-map-4.4.2.tgz"
   checksum: 10c0/cc7e15dc4acf6d9ef663757279600bab70533d847dcc1ab01332e9e680bd30b77cdf9ad885cc774276f51d98b05a013571c940e5b360985af5eb798dc1a2ee2b
+  languageName: node
+  linkType: hard
+
+"@manypkg/find-root@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@manypkg/find-root@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40manypkg%2Ffind-root%2F-%2Ffind-root-1.1.0.tgz"
+  dependencies:
+    "@babel/runtime": "npm:^7.5.5"
+    "@types/node": "npm:^12.7.1"
+    find-up: "npm:^4.1.0"
+    fs-extra: "npm:^8.1.0"
+  checksum: 10c0/0ee907698e6c73d6f1821ff630f3fec6dcf38260817c8752fec8991ac38b95ba431ab11c2773ddf9beb33d0e057f1122b00e8ffc9b8411b3fd24151413626fa6
+  languageName: node
+  linkType: hard
+
+"@manypkg/get-packages@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@manypkg/get-packages@npm:1.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40manypkg%2Fget-packages%2F-%2Fget-packages-1.1.3.tgz"
+  dependencies:
+    "@babel/runtime": "npm:^7.5.5"
+    "@changesets/types": "npm:^4.0.1"
+    "@manypkg/find-root": "npm:^1.1.0"
+    fs-extra: "npm:^8.1.0"
+    globby: "npm:^11.0.0"
+    read-yaml-file: "npm:^1.1.0"
+  checksum: 10c0/f05907d1174ae28861eaa06d0efdc144f773d9a4b8b65e1e7cdc01eb93361d335351b4a336e05c6aac02661be39e8809a3f7ad28bc67b6b338071434ab442130
   languageName: node
   linkType: hard
 
@@ -2760,6 +3026,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^12.7.1":
+  version: 12.20.55
+  resolution: "@types/node@npm:12.20.55::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnode%2F-%2Fnode-12.20.55.tgz"
+  checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^22.8.7":
   version: 22.19.7
   resolution: "@types/node@npm:22.19.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2F%40types%2Fnode%2F-%2Fnode-22.19.7.tgz"
@@ -3151,6 +3424,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "ansi-colors@npm:4.1.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-colors%2F-%2Fansi-colors-4.1.3.tgz"
+  checksum: 10c0/ec87a2f59902f74e61eada7f6e6fe20094a628dab765cfdbd03c3477599368768cffccdb5d3bb19a1b6c99126783a143b1fee31aab729b31ffe5836c7e5e28b9
+  languageName: node
+  linkType: hard
+
 "ansi-escapes@npm:^3.0.0, ansi-escapes@npm:^3.2.0":
   version: 3.2.0
   resolution: "ansi-escapes@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fansi-escapes%2F-%2Fansi-escapes-3.2.0.tgz"
@@ -3295,6 +3575,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"argparse@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fargparse%2F-%2Fargparse-1.0.10.tgz"
+  dependencies:
+    sprintf-js: "npm:~1.0.2"
+  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fargparse%2F-%2Fargparse-2.0.1.tgz"
@@ -3313,6 +3602,13 @@ __metadata:
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Farray-flatten%2F-%2Farray-flatten-1.1.1.tgz"
   checksum: 10c0/806966c8abb2f858b08f5324d9d18d7737480610f3bd5d3498aaae6eb5efdc501a884ba019c9b4a8f02ff67002058749d05548fd42fa8643f02c9c7f22198b91
+  languageName: node
+  linkType: hard
+
+"array-union@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "array-union@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Farray-union%2F-%2Farray-union-2.1.0.tgz"
+  checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
   languageName: node
   linkType: hard
 
@@ -3462,6 +3758,15 @@ __metadata:
   version: 0.6.1
   resolution: "batch@npm:0.6.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbatch%2F-%2Fbatch-0.6.1.tgz"
   checksum: 10c0/925a13897b4db80d4211082fe287bcf96d297af38e26448c857cee3e095c9792e3b8f26b37d268812e7f38a589f694609de8534a018b1937d7dc9f84e6b387c5
+  languageName: node
+  linkType: hard
+
+"better-path-resolve@npm:1.0.0":
+  version: 1.0.0
+  resolution: "better-path-resolve@npm:1.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fbetter-path-resolve%2F-%2Fbetter-path-resolve-1.0.0.tgz"
+  dependencies:
+    is-windows: "npm:^1.0.0"
+  checksum: 10c0/7335130729d59a14b8e4753fea180ca84e287cccc20cb5f2438a95667abc5810327c414eee7b3c79ed1b5a348a40284ea872958f50caba69432c40405eb0acce
   languageName: node
   linkType: hard
 
@@ -4155,7 +4460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fcross-spawn%2F-%2Fcross-spawn-7.0.6.tgz"
   dependencies:
@@ -4371,6 +4676,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-indent@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "detect-indent@npm:6.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdetect-indent%2F-%2Fdetect-indent-6.1.0.tgz"
+  checksum: 10c0/dd83cdeda9af219cf77f5e9a0dc31d828c045337386cfb55ce04fad94ba872ee7957336834154f7647b89b899c3c7acc977c57a79b7c776b506240993f97acc7
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.3":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdetect-libc%2F-%2Fdetect-libc-2.1.2.tgz"
@@ -4392,6 +4704,15 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdiff%2F-%2Fdiff-4.0.2.tgz"
   checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
+"dir-glob@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "dir-glob@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fdir-glob%2F-%2Fdir-glob-3.0.1.tgz"
+  dependencies:
+    path-type: "npm:^4.0.0"
+  checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
   languageName: node
   linkType: hard
 
@@ -4602,6 +4923,16 @@ __metadata:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
   checksum: 10c0/5738924cfe3641d04b89c2856fee3d109d7bd71bbe234fb7f54843dda65f293e5f3eee6d5970ced70dbb09016085b961e60d1eb26cac72a21044479954b6cdfd
+  languageName: node
+  linkType: hard
+
+"enquirer@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "enquirer@npm:2.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fenquirer%2F-%2Fenquirer-2.4.1.tgz"
+  dependencies:
+    ansi-colors: "npm:^4.1.1"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/43850479d7a51d36a9c924b518dcdc6373b5a8ae3401097d336b7b7e258324749d0ad37a1fcaa5706f04799baa05585cd7af19ebdf7667673e7694435fcea918
   languageName: node
   linkType: hard
 
@@ -4940,6 +5271,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esprima@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fesprima%2F-%2Fesprima-4.0.1.tgz"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
+  languageName: node
+  linkType: hard
+
 "estree-walker@npm:^3.0.0, estree-walker@npm:^3.0.3":
   version: 3.0.3
   resolution: "estree-walker@npm:3.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Festree-walker%2F-%2Festree-walker-3.0.3.tgz"
@@ -5063,6 +5404,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extendable-error@npm:^0.1.5":
+  version: 0.1.7
+  resolution: "extendable-error@npm:0.1.7::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fextendable-error%2F-%2Fextendable-error-0.1.7.tgz"
+  checksum: 10c0/c46648b7682448428f81b157cbfe480170fd96359c55db477a839ddeaa34905a18cba0b989bafe5e83f93c2491a3fcc7cc536063ea326ba9d72e9c6e2fe736a7
+  languageName: node
+  linkType: hard
+
 "external-editor@npm:^3.0.3":
   version: 3.1.0
   resolution: "external-editor@npm:3.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fexternal-editor%2F-%2Fexternal-editor-3.1.0.tgz"
@@ -5088,7 +5436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffast-glob%2F-%2Ffast-glob-3.3.3.tgz"
   dependencies:
@@ -5222,7 +5570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.0.0":
+"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffind-up%2F-%2Ffind-up-4.1.0.tgz"
   dependencies:
@@ -5320,6 +5668,28 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/984924ff4104e3e9f351b658a864bf3b354b2c90429f57aec0acd12d92c4e6b762cbacacdffb4e745b280adce882e1f980c485d9f02c453f769ab4e7fc646ce3
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "fs-extra@npm:7.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs-extra%2F-%2Ffs-extra-7.0.1.tgz"
+  dependencies:
+    graceful-fs: "npm:^4.1.2"
+    jsonfile: "npm:^4.0.0"
+    universalify: "npm:^0.1.0"
+  checksum: 10c0/1943bb2150007e3739921b8d13d4109abdc3cc481e53b97b7ea7f77eda1c3c642e27ae49eac3af074e3496ea02fde30f411ef410c760c70a38b92e656e5da784
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "fs-extra@npm:8.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffs-extra%2F-%2Ffs-extra-8.1.0.tgz"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^4.0.0"
+    universalify: "npm:^0.1.0"
+  checksum: 10c0/259f7b814d9e50d686899550c4f9ded85c46c643f7fe19be69504888e007fcbc08f306fae8ec495b8b998635e997c9e3e175ff2eeed230524ef1c1684cc96423
   languageName: node
   linkType: hard
 
@@ -5535,6 +5905,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globby@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "globby@npm:11.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglobby%2F-%2Fglobby-11.1.0.tgz"
+  dependencies:
+    array-union: "npm:^2.1.0"
+    dir-glob: "npm:^3.0.1"
+    fast-glob: "npm:^3.2.9"
+    ignore: "npm:^5.2.0"
+    merge2: "npm:^1.4.1"
+    slash: "npm:^3.0.0"
+  checksum: 10c0/b39511b4afe4bd8a7aead3a27c4ade2b9968649abab0a6c28b1a90141b96ca68ca5db1302f7c7bd29eab66bf51e13916b8e0a3d0ac08f75e1e84a39b35691189
+  languageName: node
+  linkType: hard
+
 "globby@npm:^14.0.2":
   version: 14.1.0
   resolution: "globby@npm:14.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fglobby%2F-%2Fglobby-14.1.0.tgz"
@@ -5604,7 +5988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.5, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fgraceful-fs%2F-%2Fgraceful-fs-4.2.11.tgz"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -5849,6 +6233,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-id@npm:^4.1.1":
+  version: 4.2.0
+  resolution: "human-id@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhuman-id%2F-%2Fhuman-id-4.2.0.tgz"
+  bin:
+    human-id: dist/cli.js
+  checksum: 10c0/80071f3b785b2e91080b5f9aa2d079c2e9a464e009ea12c035255b61d1b70beefe7eda42209dff9c1bb9a9fa58e50ada38c1b314ba3a23266a72cd5e9a453e1f
+  languageName: node
+  linkType: hard
+
 "human-signals@npm:^5.0.0":
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fhuman-signals%2F-%2Fhuman-signals-5.0.0.tgz"
@@ -5907,6 +6300,13 @@ __metadata:
   dependencies:
     minimatch: "npm:^9.0.0"
   checksum: 10c0/3754bcde369a53a92c1d0835ea93feb6c5b2934984d3f5a8f9dd962d13ac33ee3a9e930901a89b5d46fc061870639d983f497186afdfe3484e135f2ad89f5577
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.2.0":
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fignore%2F-%2Fignore-5.3.2.tgz"
+  checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
   languageName: node
   linkType: hard
 
@@ -6342,6 +6742,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-subdir@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "is-subdir@npm:1.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-subdir%2F-%2Fis-subdir-1.2.0.tgz"
+  dependencies:
+    better-path-resolve: "npm:1.0.0"
+  checksum: 10c0/03a03ee2ee6578ce589b1cfaf00e65c86b20fd1b82c1660625557c535439a7477cda77e20c62cda6d4c99e7fd908b4619355ae2d989f4a524a35350a44353032
+  languageName: node
+  linkType: hard
+
 "is-unicode-supported@npm:^2.0.0":
   version: 2.1.0
   resolution: "is-unicode-supported@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-unicode-supported%2F-%2Fis-unicode-supported-2.1.0.tgz"
@@ -6370,6 +6779,13 @@ __metadata:
   version: 3.14.1
   resolution: "is-what@npm:3.14.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-what%2F-%2Fis-what-3.14.1.tgz"
   checksum: 10c0/4b770b85454c877b6929a84fd47c318e1f8c2ff70fd72fd625bc3fde8e0c18a6e57345b6e7aa1ee9fbd1c608d27cfe885df473036c5c2e40cd2187250804a2c7
+  languageName: node
+  linkType: hard
+
+"is-windows@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "is-windows@npm:1.0.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fis-windows%2F-%2Fis-windows-1.0.2.tgz"
+  checksum: 10c0/b32f418ab3385604a66f1b7a3ce39d25e8881dee0bd30816dc8344ef6ff9df473a732bcc1ec4e84fe99b2f229ae474f7133e8e93f9241686cfcf7eebe53ba7a5
   languageName: node
   linkType: hard
 
@@ -6468,6 +6884,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:^3.6.1":
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-yaml%2F-%2Fjs-yaml-3.15.0.tgz"
+  dependencies:
+    argparse: "npm:^1.0.7"
+    esprima: "npm:^4.0.0"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^4.1.0":
   version: 4.1.1
   resolution: "js-yaml@npm:4.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-yaml%2F-%2Fjs-yaml-4.1.1.tgz"
@@ -6476,6 +6904,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.1.1":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjs-yaml%2F-%2Fjs-yaml-4.3.0.tgz"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -6517,6 +6956,18 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 10c0/5a04eed94810fa55c5ea138b2f7a5c12b97c3750bc63d11e511dcecbfef758003861522a070c2272764ee0f4e3e323862f386945aeb5b85b87ee43f084ba586c
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jsonfile@npm:4.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fjsonfile%2F-%2Fjsonfile-4.0.0.tgz"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
   languageName: node
   linkType: hard
 
@@ -6862,6 +7313,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.startcase@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.startcase@npm:4.4.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.startcase%2F-%2Flodash.startcase-4.4.0.tgz"
+  checksum: 10c0/bd82aa87a45de8080e1c5ee61128c7aee77bf7f1d86f4ff94f4a6d7438fc9e15e5f03374b947be577a93804c8ad6241f0251beaf1452bf716064eeb657b3a9f0
+  languageName: node
+  linkType: hard
+
 "lodash.zip@npm:^4.2.0":
   version: 4.2.0
   resolution: "lodash.zip@npm:4.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Flodash.zip%2F-%2Flodash.zip-4.2.0.tgz"
@@ -7077,7 +7535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0":
+"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fmerge2%2F-%2Fmerge2-1.4.1.tgz"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
@@ -7744,6 +8202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outdent@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "outdent@npm:0.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foutdent%2F-%2Foutdent-0.5.0.tgz"
+  checksum: 10c0/e216a4498889ba1babae06af84cdc4091f7cac86da49d22d0163b3be202a5f52efcd2bcd3dfca60a361eb3a27b4299f185c5655061b6b402552d7fcd1d040cff
+  languageName: node
+  linkType: hard
+
 "oxc-parser@npm:^0.96.0":
   version: 0.96.0
   resolution: "oxc-parser@npm:0.96.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Foxc-parser%2F-%2Foxc-parser-0.96.0.tgz"
@@ -7919,6 +8384,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-filter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "p-filter@npm:2.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-filter%2F-%2Fp-filter-2.1.0.tgz"
+  dependencies:
+    p-map: "npm:^2.0.0"
+  checksum: 10c0/5ac34b74b3b691c04212d5dd2319ed484f591c557a850a3ffc93a08cb38c4f5540be059c6b10a185773c479ca583a91ea00c7d6c9958c815e6b74d052f356645
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fp-limit%2F-%2Fp-limit-2.3.0.tgz"
@@ -8006,6 +8480,7 @@ __metadata:
   resolution: "package-build-stats@workspace:."
   dependencies:
     "@babel/core": "npm:^7.28.5"
+    "@changesets/cli": "npm:^2.31.1"
     "@rsdoctor/rspack-plugin": "npm:^1.3.8"
     "@rspack/core": "npm:^1.6.0"
     "@swc/core": "npm:^1.14.0"
@@ -8084,6 +8559,15 @@ __metadata:
     registry-url: "npm:^6.0.1"
     semver: "npm:^7.6.0"
   checksum: 10c0/4a55648d820496326730a7b149fd3fd8382e96f3d6def5ec687f46b75063894acf06b21f79832b40bb094c821d97f532cb0f009f85c4102d0084b488d4f492d3
+  languageName: node
+  linkType: hard
+
+"package-manager-detector@npm:^0.2.0":
+  version: 0.2.11
+  resolution: "package-manager-detector@npm:0.2.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpackage-manager-detector%2F-%2Fpackage-manager-detector-0.2.11.tgz"
+  dependencies:
+    quansync: "npm:^0.2.7"
+  checksum: 10c0/247991de461b9e731f3463b7dae9ce187e53095b7b94d7d96eec039abf418b61ccf74464bec1d0c11d97311f33472e77baccd4c5898f77358da4b5b33395e0b1
   languageName: node
   linkType: hard
 
@@ -8245,7 +8729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpicocolors%2F-%2Fpicocolors-1.1.1.tgz"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -8415,6 +8899,15 @@ __metadata:
   version: 0.0.1
   resolution: "presentable-error@npm:0.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fpresentable-error%2F-%2Fpresentable-error-0.0.1.tgz"
   checksum: 10c0/84a0ef6f2c34fbb1ee006b803b9e6df52886b39ae431f0359364f8a8b74b41ca98976217fdced80bf56a9dee05fa2b456cbb57323cfc3e135bce8825ec5e8650
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.7.1":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fprettier%2F-%2Fprettier-2.8.8.tgz"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
   languageName: node
   linkType: hard
 
@@ -8679,6 +9172,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"quansync@npm:^0.2.7":
+  version: 0.2.11
+  resolution: "quansync@npm:0.2.11::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fquansync%2F-%2Fquansync-0.2.11.tgz"
+  checksum: 10c0/cb9a1f8ebce074069f2f6a78578873ffedd9de9f6aa212039b44c0870955c04a71c3b1311b5d97f8ac2f2ec476de202d0a5c01160cb12bc0a11b7ef36d22ef56
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fqueue-microtask%2F-%2Fqueue-microtask-1.2.3.tgz"
@@ -8747,6 +9247,18 @@ __metadata:
     type-fest: "npm:^4.6.0"
     unicorn-magic: "npm:^0.1.0"
   checksum: 10c0/f3e27549dcdb18335597f4125a3d093a40ab0a18c16a6929a1575360ed5d8679b709b4a672730d9abf6aa8537a7f02bae0b4b38626f99409255acbd8f72f9964
+  languageName: node
+  linkType: hard
+
+"read-yaml-file@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "read-yaml-file@npm:1.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fread-yaml-file%2F-%2Fread-yaml-file-1.1.0.tgz"
+  dependencies:
+    graceful-fs: "npm:^4.1.5"
+    js-yaml: "npm:^3.6.1"
+    pify: "npm:^4.0.1"
+    strip-bom: "npm:^3.0.0"
+  checksum: 10c0/85a9ba08bb93f3c91089bab4f1603995ec7156ee595f8ce40ae9f49d841cbb586511508bd47b7cf78c97f678c679b2c6e2c0092e63f124214af41b6f8a25ca31
   languageName: node
   linkType: hard
 
@@ -9411,6 +9923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "slash@npm:3.0.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fslash%2F-%2Fslash-3.0.0.tgz"
+  checksum: 10c0/e18488c6a42bdfd4ac5be85b2ced3ccd0224773baae6ad42cfbb9ec74fc07f9fa8396bd35ee638084ead7a2a0818eb5e7151111544d4731ce843019dab4be47b
+  languageName: node
+  linkType: hard
+
 "slash@npm:^5.1.0":
   version: 5.1.0
   resolution: "slash@npm:5.1.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fslash%2F-%2Fslash-5.1.0.tgz"
@@ -9534,6 +10053,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"spawndamnit@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "spawndamnit@npm:3.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspawndamnit%2F-%2Fspawndamnit-3.0.1.tgz"
+  dependencies:
+    cross-spawn: "npm:^7.0.5"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10c0/a9821a59bc78a665bd44718dea8f4f4010bb1a374972b0a6a1633b9186cda6d6fd93f22d1e49d9944d6bb175ba23ce29036a4bd624884fb157d981842c3682f3
+  languageName: node
+  linkType: hard
+
 "spdx-correct@npm:^3.0.0":
   version: 3.2.0
   resolution: "spdx-correct@npm:3.2.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspdx-correct%2F-%2Fspdx-correct-3.2.0.tgz"
@@ -9572,6 +10101,13 @@ __metadata:
   version: 14.0.1
   resolution: "speakingurl@npm:14.0.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fspeakingurl%2F-%2Fspeakingurl-14.0.1.tgz"
   checksum: 10c0/1de1d1b938a7c4d9e79593ff7a26d312ec04a7c3234ca40b7f9b8106daf74ea9d2110a077f5db97ecf3762b83069e3ccbf9694431b51d4fcfd863f0b3333c342
+  languageName: node
+  linkType: hard
+
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fsprintf-js%2F-%2Fsprintf-js-1.0.3.tgz"
+  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 
@@ -9927,6 +10463,13 @@ __metadata:
     stream-events: "npm:^1.0.5"
     uuid: "npm:^9.0.0"
   checksum: 10c0/1c51a284075b57b7b7f970fc8d855d611912f0e485aa1d1dfda3c0be3f2df392e4ce83b1b39877134041abb7c255f3777f175b27323ef5bf008839e42a1958bc
+  languageName: node
+  linkType: hard
+
+"term-size@npm:^2.1.0":
+  version: 2.2.1
+  resolution: "term-size@npm:2.2.1::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Fterm-size%2F-%2Fterm-size-2.2.1.tgz"
+  checksum: 10c0/89f6bba1d05d425156c0910982f9344d9e4aebf12d64bfa1f460d93c24baa7bc4c4a21d355fbd7153c316433df0538f64d0ae6e336cc4a69fdda4f85d62bc79d
   languageName: node
   linkType: hard
 
@@ -10326,6 +10869,13 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/da7ade4cb04eb33ad0499861f82fe95ce9c7c878b7139dc54d140ecfb6a6541c18a5c8dac16188b8b379fe62c0c1f1b710814baac910cde5f4fec06212126c6a
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "universalify@npm:0.1.2::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Funiversalify%2F-%2Funiversalify-0.1.2.tgz"
+  checksum: 10c0/e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add Changesets CLI, configuration, and contributor guidance
- add a release-PR workflow that publishes merged versions to npm
- use npm trusted publishing (OIDC) with provenance instead of a long-lived token
- make prepack validation non-mutating

## Validation
- type check, lint, and formatting pass (existing warnings only)
- 32 fast tests pass
- TypeScript build passes
- npm pack dry-run contains the expected 44 files

## One-time post-merge setup
Configure the npm trusted publisher for `package-build-stats` as:
- owner: `pastelsky`
- repository: `package-build-stats`
- workflow: `release.yml`
- allowed action: `npm publish`

No `NPM_TOKEN` secret is required.