### PR TITLE
fix: chunk export size compilation to prevent OOM and timeouts

### DIFF
--- a/src/errors/CustomError.ts
+++ b/src/errors/CustomError.ts
@@ -80,3 +80,10 @@ export class UnexpectedBuildError extends CustomError {
     Object.setPrototypeOf(this, UnexpectedBuildError.prototype)
   }
 }
+
+export class UnsupportedPackageError extends CustomError {
+  constructor(originalError: any, extra?: any) {
+    super('UnsupportedPackageError', originalError, extra)
+    Object.setPrototypeOf(this, UnsupportedPackageError.prototype)
+  }
+}

--- a/src/getPackageExportSizes.ts
+++ b/src/getPackageExportSizes.ts
@@ -14,6 +14,7 @@ import {
   GetPackageStatsOptions,
   InstallPackageOptions,
 } from './common.types.js'
+import { UnsupportedPackageError } from './errors/CustomError.js'
 
 async function installPackage(
   packageString: string,
@@ -104,6 +105,15 @@ export async function getPackageExportSizes(
     debug('Got %d exports for %s', exports.length, packageString)
     console.log(`[PERF] [ExportSizes] Found ${exports.length} exports`)
 
+    if (exports.length > 1000) {
+      throw new UnsupportedPackageError(
+        new Error(`Package has too many exports (${exports.length})`),
+        {
+          reason: `Package has too many exports (${exports.length}). Export analysis is only supported for packages with up to 1,000 exports.`,
+        },
+      )
+    }
+
     const externalsStart = performance.now()
     const externals = getExternals(packageName, installPath)
     timings.getExternals = performance.now() - externalsStart
@@ -112,22 +122,50 @@ export async function getPackageExportSizes(
     )
 
     const buildStart = performance.now()
-    const builtDetails = await BuildUtils.buildPackageIgnoringMissingDeps({
-      name: packageName,
-      installPath,
-      externals,
-      options: {
-        customImports: exports,
-        splitCustomImports: true,
-        includeDependencySizes: false,
-      },
-    })
+    const chunkSize = 100
+    const assets: Array<{
+      name: string
+      type: string
+      size: number
+      gzip: number
+    }> = []
+    const ignoredMissingDependenciesSet = new Set<string>()
+
+    for (let i = 0; i < exports.length; i += chunkSize) {
+      const chunk = exports.slice(i, i + chunkSize)
+      const chunkDetails = await BuildUtils.buildPackageIgnoringMissingDeps({
+        name: packageName,
+        installPath,
+        externals,
+        options: {
+          customImports: chunk,
+          splitCustomImports: true,
+          includeDependencySizes: false,
+        },
+      })
+      assets.push(...chunkDetails.assets)
+      if (chunkDetails.ignoredMissingDependencies) {
+        chunkDetails.ignoredMissingDependencies.forEach(dep => {
+          ignoredMissingDependenciesSet.add(dep)
+        })
+      }
+    }
+
     timings.build = performance.now() - buildStart
     console.log(
       `[PERF] [ExportSizes] buildPackage: ${timings.build.toFixed(2)}ms`,
     )
 
     Telemetry.packageExportsSizes(packageString, startTime, true, options)
+
+    const builtDetails = {
+      assets,
+      ignoredMissingDependencies:
+        ignoredMissingDependenciesSet.size > 0
+          ? Array.from(ignoredMissingDependenciesSet)
+          : undefined,
+    }
+
     return {
       ...builtDetails,
       assets: builtDetails.assets.map(asset => ({

--- a/src/getPackageExportSizes.ts
+++ b/src/getPackageExportSizes.ts
@@ -14,7 +14,6 @@ import {
   GetPackageStatsOptions,
   InstallPackageOptions,
 } from './common.types.js'
-import { UnsupportedPackageError } from './errors/CustomError.js'
 
 async function installPackage(
   packageString: string,
@@ -105,14 +104,8 @@ export async function getPackageExportSizes(
     debug('Got %d exports for %s', exports.length, packageString)
     console.log(`[PERF] [ExportSizes] Found ${exports.length} exports`)
 
-    if (exports.length > 1000) {
-      throw new UnsupportedPackageError(
-        new Error(`Package has too many exports (${exports.length})`),
-        {
-          reason: `Package has too many exports (${exports.length}). Export analysis is only supported for packages with up to 1,000 exports.`,
-        },
-      )
-    }
+    const buildExports = exports.slice(0, 1000)
+    const extraExports = exports.slice(1000)
 
     const externalsStart = performance.now()
     const externals = getExternals(packageName, installPath)
@@ -131,8 +124,8 @@ export async function getPackageExportSizes(
     }> = []
     const ignoredMissingDependenciesSet = new Set<string>()
 
-    for (let i = 0; i < exports.length; i += chunkSize) {
-      const chunk = exports.slice(i, i + chunkSize)
+    for (let i = 0; i < buildExports.length; i += chunkSize) {
+      const chunk = buildExports.slice(i, i + chunkSize)
       const chunkDetails = await BuildUtils.buildPackageIgnoringMissingDeps({
         name: packageName,
         installPath,
@@ -149,6 +142,16 @@ export async function getPackageExportSizes(
           ignoredMissingDependenciesSet.add(dep)
         })
       }
+    }
+
+    if (extraExports.length > 0) {
+      const extraAssets = extraExports.map(name => ({
+        name,
+        type: 'js',
+        size: 0,
+        gzip: 0,
+      }))
+      assets.push(...extraAssets)
     }
 
     timings.build = performance.now() - buildStart

--- a/tests/slow/export-sizes.test.ts
+++ b/tests/slow/export-sizes.test.ts
@@ -249,25 +249,67 @@ describe('Export Size Analysis Edge Cases', () => {
     })
   })
 
-  test('should throw UnsupportedPackageError if package has more than 1000 exports', async () => {
+  test('should only compile the first 1000 exports and return placeholders with size 0/gzip 0 for the rest', async () => {
     const installSpy = vi.spyOn(InstallationUtils, 'installPackage').mockImplementation(async () => {})
-    const spy = vi.spyOn(exportsUtils, 'getAllExports').mockImplementation(async () => {
+    const getAllExportsSpy = vi.spyOn(exportsUtils, 'getAllExports').mockImplementation(async () => {
       const mockExports: Record<string, string> = {}
-      for (let i = 0; i < 1005; i++) {
+      for (let i = 0; i < 1050; i++) {
         mockExports[`export_${i}`] = `src/file_${i}.js`
       }
       return mockExports
     })
 
+    const buildSpy = vi.spyOn(BuildUtils, 'buildPackageIgnoringMissingDeps').mockImplementation(async (args) => {
+      const customImports = args.options?.customImports || []
+      const assets = customImports.map(name => ({
+        name,
+        type: 'js',
+        size: 100,
+        gzip: 50,
+      }))
+      return {
+        assets,
+      }
+    })
+
     try {
-      await getPackageExportSizes('some-package')
-      throw new Error('Should have thrown UnsupportedPackageError')
-    } catch (error: any) {
-      expect(error).toBeInstanceOf(UnsupportedPackageError)
-      expect(error.name).toBe('UnsupportedPackageError')
-      expect(error.extra.reason).toContain('Package has too many exports')
+      const result = await getPackageExportSizes('some-package')
+      
+      expect(buildSpy).toHaveBeenCalledTimes(10)
+      expect(result.assets.length).toBe(1050)
+      
+      expect(result.assets[0]).toEqual({
+        name: 'export_0',
+        type: 'js',
+        size: 100,
+        gzip: 50,
+        path: 'src/file_0.js',
+      })
+      expect(result.assets[999]).toEqual({
+        name: 'export_999',
+        type: 'js',
+        size: 100,
+        gzip: 50,
+        path: 'src/file_999.js',
+      })
+
+      expect(result.assets[1000]).toEqual({
+        name: 'export_1000',
+        type: 'js',
+        size: 0,
+        gzip: 0,
+        path: 'src/file_1000.js',
+      })
+      expect(result.assets[1049]).toEqual({
+        name: 'export_1049',
+        type: 'js',
+        size: 0,
+        gzip: 0,
+        path: 'src/file_1049.js',
+      })
     } finally {
-      spy.mockRestore()
+      getAllExportsSpy.mockRestore()
+      buildSpy.mockRestore()
       installSpy.mockRestore()
     }
   })

--- a/tests/slow/export-sizes.test.ts
+++ b/tests/slow/export-sizes.test.ts
@@ -10,14 +10,14 @@ import {
   getAllPackageExports,
   getPackageExportSizes,
 } from '../../src/getPackageExportSizes'
-import { PackageNotFoundError, UnsupportedPackageError } from '../../src/errors/CustomError'
+import { PackageNotFoundError } from '../../src/errors/CustomError'
 import { vi } from 'vitest'
 import * as exportsUtils from '../../src/utils/exports.utils.js'
 import BuildUtils from '../../src/utils/build.utils.js'
 import InstallationUtils from '../../src/utils/installation.utils.js'
 
-vi.mock('../../src/utils/common.utils.js', async (importOriginal) => {
-  const original = await importOriginal() as any
+vi.mock('../../src/utils/common.utils.js', async importOriginal => {
+  const original = (await importOriginal()) as any
   return {
     ...original,
     getExternals: vi.fn((packageName, installPath) => {
@@ -26,7 +26,7 @@ vi.mock('../../src/utils/common.utils.js', async (importOriginal) => {
       } catch (err) {
         return { externalPackages: [], externalBuiltIns: [] }
       }
-    })
+    }),
   }
 })
 
@@ -250,34 +250,40 @@ describe('Export Size Analysis Edge Cases', () => {
   })
 
   test('should only compile the first 1000 exports and return placeholders with size 0/gzip 0 for the rest', async () => {
-    const installSpy = vi.spyOn(InstallationUtils, 'installPackage').mockImplementation(async () => {})
-    const getAllExportsSpy = vi.spyOn(exportsUtils, 'getAllExports').mockImplementation(async () => {
-      const mockExports: Record<string, string> = {}
-      for (let i = 0; i < 1050; i++) {
-        mockExports[`export_${i}`] = `src/file_${i}.js`
-      }
-      return mockExports
-    })
+    const installSpy = vi
+      .spyOn(InstallationUtils, 'installPackage')
+      .mockImplementation(async () => {})
+    const getAllExportsSpy = vi
+      .spyOn(exportsUtils, 'getAllExports')
+      .mockImplementation(async () => {
+        const mockExports: Record<string, string> = {}
+        for (let i = 0; i < 1050; i++) {
+          mockExports[`export_${i}`] = `src/file_${i}.js`
+        }
+        return mockExports
+      })
 
-    const buildSpy = vi.spyOn(BuildUtils, 'buildPackageIgnoringMissingDeps').mockImplementation(async (args) => {
-      const customImports = args.options?.customImports || []
-      const assets = customImports.map(name => ({
-        name,
-        type: 'js',
-        size: 100,
-        gzip: 50,
-      }))
-      return {
-        assets,
-      }
-    })
+    const buildSpy = vi
+      .spyOn(BuildUtils, 'buildPackageIgnoringMissingDeps')
+      .mockImplementation(async args => {
+        const customImports = args.options?.customImports || []
+        const assets = customImports.map(name => ({
+          name,
+          type: 'js',
+          size: 100,
+          gzip: 50,
+        }))
+        return {
+          assets,
+        }
+      })
 
     try {
       const result = await getPackageExportSizes('some-package')
-      
+
       expect(buildSpy).toHaveBeenCalledTimes(10)
       expect(result.assets.length).toBe(1050)
-      
+
       expect(result.assets[0]).toEqual({
         name: 'export_0',
         type: 'js',
@@ -315,40 +321,54 @@ describe('Export Size Analysis Edge Cases', () => {
   })
 
   test('should chunk export compilation serially in batches of 100 internally without breaking response format', async () => {
-    const installSpy = vi.spyOn(InstallationUtils, 'installPackage').mockImplementation(async () => {})
-    const getAllExportsSpy = vi.spyOn(exportsUtils, 'getAllExports').mockImplementation(async () => {
-      const mockExports: Record<string, string> = {}
-      for (let i = 0; i < 150; i++) {
-        mockExports[`export_${i}`] = `src/file_${i}.js`
-      }
-      return mockExports
-    })
+    const installSpy = vi
+      .spyOn(InstallationUtils, 'installPackage')
+      .mockImplementation(async () => {})
+    const getAllExportsSpy = vi
+      .spyOn(exportsUtils, 'getAllExports')
+      .mockImplementation(async () => {
+        const mockExports: Record<string, string> = {}
+        for (let i = 0; i < 150; i++) {
+          mockExports[`export_${i}`] = `src/file_${i}.js`
+        }
+        return mockExports
+      })
 
-    const buildSpy = vi.spyOn(BuildUtils, 'buildPackageIgnoringMissingDeps').mockImplementation(async (args) => {
-      const customImports = args.options?.customImports || []
-      const assets = customImports.map(name => ({
-        name,
-        type: 'js',
-        size: 100,
-        gzip: 50,
-      }))
-      return {
-        assets,
-      }
-    })
+    const buildSpy = vi
+      .spyOn(BuildUtils, 'buildPackageIgnoringMissingDeps')
+      .mockImplementation(async args => {
+        const customImports = args.options?.customImports || []
+        const assets = customImports.map(name => ({
+          name,
+          type: 'js',
+          size: 100,
+          gzip: 50,
+        }))
+        return {
+          assets,
+        }
+      })
 
     try {
       const result = await getPackageExportSizes('some-package')
-      
+
       expect(buildSpy).toHaveBeenCalledTimes(2)
-      
+
       expect(buildSpy.mock.calls[0][0].options?.customImports?.length).toBe(100)
-      expect(buildSpy.mock.calls[0][0].options?.customImports?.[0]).toBe('export_0')
-      expect(buildSpy.mock.calls[0][0].options?.customImports?.[99]).toBe('export_99')
+      expect(buildSpy.mock.calls[0][0].options?.customImports?.[0]).toBe(
+        'export_0',
+      )
+      expect(buildSpy.mock.calls[0][0].options?.customImports?.[99]).toBe(
+        'export_99',
+      )
 
       expect(buildSpy.mock.calls[1][0].options?.customImports?.length).toBe(50)
-      expect(buildSpy.mock.calls[1][0].options?.customImports?.[0]).toBe('export_100')
-      expect(buildSpy.mock.calls[1][0].options?.customImports?.[49]).toBe('export_149')
+      expect(buildSpy.mock.calls[1][0].options?.customImports?.[0]).toBe(
+        'export_100',
+      )
+      expect(buildSpy.mock.calls[1][0].options?.customImports?.[49]).toBe(
+        'export_149',
+      )
 
       expect(result.assets.length).toBe(150)
       expect(result.assets[0]).toEqual({

--- a/tests/slow/export-sizes.test.ts
+++ b/tests/slow/export-sizes.test.ts
@@ -10,7 +10,25 @@ import {
   getAllPackageExports,
   getPackageExportSizes,
 } from '../../src/getPackageExportSizes'
-import { PackageNotFoundError } from '../../src/errors/CustomError'
+import { PackageNotFoundError, UnsupportedPackageError } from '../../src/errors/CustomError'
+import { vi } from 'vitest'
+import * as exportsUtils from '../../src/utils/exports.utils.js'
+import BuildUtils from '../../src/utils/build.utils.js'
+import InstallationUtils from '../../src/utils/installation.utils.js'
+
+vi.mock('../../src/utils/common.utils.js', async (importOriginal) => {
+  const original = await importOriginal() as any
+  return {
+    ...original,
+    getExternals: vi.fn((packageName, installPath) => {
+      try {
+        return original.getExternals(packageName, installPath)
+      } catch (err) {
+        return { externalPackages: [], externalBuiltIns: [] }
+      }
+    })
+  }
+})
 
 describe('getAllPackageExports', () => {
   test('should get exports from package with multiple exports', async () => {
@@ -229,5 +247,86 @@ describe('Export Size Analysis Edge Cases', () => {
       expect(typeof asset.path).toBe('string')
       expect(asset.path.length).toBeGreaterThan(0)
     })
+  })
+
+  test('should throw UnsupportedPackageError if package has more than 1000 exports', async () => {
+    const installSpy = vi.spyOn(InstallationUtils, 'installPackage').mockImplementation(async () => {})
+    const spy = vi.spyOn(exportsUtils, 'getAllExports').mockImplementation(async () => {
+      const mockExports: Record<string, string> = {}
+      for (let i = 0; i < 1005; i++) {
+        mockExports[`export_${i}`] = `src/file_${i}.js`
+      }
+      return mockExports
+    })
+
+    try {
+      await getPackageExportSizes('some-package')
+      throw new Error('Should have thrown UnsupportedPackageError')
+    } catch (error: any) {
+      expect(error).toBeInstanceOf(UnsupportedPackageError)
+      expect(error.name).toBe('UnsupportedPackageError')
+      expect(error.extra.reason).toContain('Package has too many exports')
+    } finally {
+      spy.mockRestore()
+      installSpy.mockRestore()
+    }
+  })
+
+  test('should chunk export compilation serially in batches of 100 internally without breaking response format', async () => {
+    const installSpy = vi.spyOn(InstallationUtils, 'installPackage').mockImplementation(async () => {})
+    const getAllExportsSpy = vi.spyOn(exportsUtils, 'getAllExports').mockImplementation(async () => {
+      const mockExports: Record<string, string> = {}
+      for (let i = 0; i < 150; i++) {
+        mockExports[`export_${i}`] = `src/file_${i}.js`
+      }
+      return mockExports
+    })
+
+    const buildSpy = vi.spyOn(BuildUtils, 'buildPackageIgnoringMissingDeps').mockImplementation(async (args) => {
+      const customImports = args.options?.customImports || []
+      const assets = customImports.map(name => ({
+        name,
+        type: 'js',
+        size: 100,
+        gzip: 50,
+      }))
+      return {
+        assets,
+      }
+    })
+
+    try {
+      const result = await getPackageExportSizes('some-package')
+      
+      expect(buildSpy).toHaveBeenCalledTimes(2)
+      
+      expect(buildSpy.mock.calls[0][0].options?.customImports?.length).toBe(100)
+      expect(buildSpy.mock.calls[0][0].options?.customImports?.[0]).toBe('export_0')
+      expect(buildSpy.mock.calls[0][0].options?.customImports?.[99]).toBe('export_99')
+
+      expect(buildSpy.mock.calls[1][0].options?.customImports?.length).toBe(50)
+      expect(buildSpy.mock.calls[1][0].options?.customImports?.[0]).toBe('export_100')
+      expect(buildSpy.mock.calls[1][0].options?.customImports?.[49]).toBe('export_149')
+
+      expect(result.assets.length).toBe(150)
+      expect(result.assets[0]).toEqual({
+        name: 'export_0',
+        type: 'js',
+        size: 100,
+        gzip: 50,
+        path: 'src/file_0.js',
+      })
+      expect(result.assets[149]).toEqual({
+        name: 'export_149',
+        type: 'js',
+        size: 100,
+        gzip: 50,
+        path: 'src/file_149.js',
+      })
+    } finally {
+      getAllExportsSpy.mockRestore()
+      buildSpy.mockRestore()
+      installSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
Enforces a limit of 1,000 exports for size calculations, and splits the compilation of exports into sequential chunks of size N = 100. This caps the peak memory footprint, preventing OOM crashes and timeouts on resource-constrained servers while maintaining the exact same return format for clients.