### PR TITLE
Release package-build-stats 8.3.0

### DIFF
--- a/.changeset/fair-tools-build.md
+++ b/.changeset/fair-tools-build.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': minor
+---
+
+Improve package export analysis by handling multi-output chunks and surfacing invalid exports clearly.


### PR DESCRIPTION
Adds the missing minor changeset for the export-analysis improvements merged in #77. Changesets will open the generated version PR after this merges.