### PR TITLE
Skip module stats for export size builds

### DIFF
--- a/.changeset/tidy-export-stats.md
+++ b/.changeset/tidy-export-stats.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': patch
+---
+
+Skip Rspack module and source serialization when dependency sizes are not requested.

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -64,13 +64,17 @@ type BuildPackageResultWithIgnored = BuildPackageResult & {
 type RspackStatsCompilation = ReturnType<Stats['toJson']>
 type RspackStatsAsset = NonNullable<RspackStatsCompilation['assets']>[0]
 
-const PACKAGE_STATS_OPTIONS: StatsOptions = {
+const ASSET_STATS_OPTIONS: StatsOptions = {
   all: false,
 
   assets: true,
   cachedAssets: true,
   assetsSpace: Number.POSITIVE_INFINITY,
   assetsSort: '!size',
+}
+
+const DEPENDENCY_STATS_OPTIONS: StatsOptions = {
+  ...ASSET_STATS_OPTIONS,
 
   modules: true,
   cachedModules: true,
@@ -284,7 +288,11 @@ const BuildUtils = {
     }
 
     const jsonStatsStartTime = performance.now()
-    const jsonStats = stats.toJson(PACKAGE_STATS_OPTIONS)
+    const jsonStats = stats.toJson(
+      options.includeDependencySizes
+        ? DEPENDENCY_STATS_OPTIONS
+        : ASSET_STATS_OPTIONS,
+    )
 
     if (!jsonStats) {
       Telemetry.parseWebpackStats(packageName, false, jsonStatsStartTime)


### PR DESCRIPTION
## Summary

- use an asset-only Rspack stats profile when dependency sizes are disabled
- retain the full module/source profile for dependency-size builds
- add a patch changeset

This builds on the stats-profile optimization merged in #84.

## Memory impact

`getPackageExportSizes` builds exports in batches of up to 100 and explicitly disables dependency sizes, but it previously serialized every module and full source text for each batch.

For `date-fns@4.1.0` across three export batches:

- dependency stats profile: 9,554,603 serialized JSON bytes
- asset-only profile: 192,818 serialized JSON bytes
- reduction: about 98%

This measures the serialized stats payload rather than process RSS.

## Compatibility

Compared `getPackageExportSizes` between master and this branch for 15 subjects: lodash, React, Axios, Day.js, Nano ID, date-fns, Zustand, Express, ESLint, normalize.css, `@types/node`, webpack, and three deterministic error fixtures.

- 14/15 results matched byte-for-byte
- the `date-fns` result showed the existing export-order and 1–2 byte nondeterminism already reproduced on master-vs-master
- no candidate-only response or structural differences were found

## Validation

- `yarn test` (33/33)
- `yarn check`
- `yarn build`
- `tests/slow/export-sizes.test.ts` (16/16)
