### PR TITLE
fix: always close rspack compiler

### DIFF
--- a/.changeset/clean-bags-close.md
+++ b/.changeset/clean-bags-close.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': patch
+---
+
+Always close the Rspack compiler when compilation fails without producing stats.

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -175,11 +175,16 @@ const BuildUtils = {
     return new Promise<CompilePackageReturn>((resolve, reject) => {
       compiler.run(async (error, stats) => {
         try {
-          if (!stats) {
-            throw new Error('stats is null')
-          }
-
           await closeCompiler(compiler)
+        } catch (closeError) {
+          reject(error && !stats ? error : closeError)
+          return
+        }
+
+        try {
+          if (!stats) {
+            throw error ?? new Error('stats is null')
+          }
 
           if (error) {
             console.error(error)
@@ -189,8 +194,8 @@ const BuildUtils = {
           }
 
           resolve({ stats, error })
-        } catch (closeError) {
-          reject(closeError)
+        } catch (buildError) {
+          reject(buildError)
         }
       })
     })

--- a/tests/fast/build.utils.test.ts
+++ b/tests/fast/build.utils.test.ts
@@ -77,6 +77,51 @@ describe('BuildUtils.compilePackage', () => {
       }),
     ).rejects.toThrow('close failed')
   })
+
+  test('closes the compiler and preserves an error returned without stats', async () => {
+    const runError = new Error('compile failed')
+    const close = vi.fn(callback => callback())
+
+    mockRspack.mockReturnValue({
+      run: (callback: (error: Error, stats?: never) => void) =>
+        callback(runError),
+      close,
+    })
+
+    await expect(
+      BuildUtils.compilePackage({
+        name: 'demo-package',
+        entry: { main: '/tmp/index.js' },
+        externals: {
+          externalPackages: [],
+          externalBuiltIns: [],
+        },
+      }),
+    ).rejects.toBe(runError)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  test('preserves the build error when compiler cleanup also fails', async () => {
+    const runError = new Error('compile failed')
+    const closeError = new Error('close failed')
+
+    mockRspack.mockReturnValue({
+      run: (callback: (error: Error, stats?: never) => void) =>
+        callback(runError),
+      close: (callback: (error: Error) => void) => callback(closeError),
+    })
+
+    await expect(
+      BuildUtils.compilePackage({
+        name: 'demo-package',
+        entry: { main: '/tmp/index.js' },
+        externals: {
+          externalPackages: [],
+          externalBuiltIns: [],
+        },
+      }),
+    ).rejects.toBe(runError)
+  })
 })
 
 describe('BuildUtils.buildPackage', () => {


### PR DESCRIPTION
## Summary
- close the Rspack compiler before settling every compile result
- preserve the original compiler error when no stats are produced, including when cleanup also fails
- add focused lifecycle regression tests and a patch changeset

## Context
Previously, compilePackage checked for missing stats before calling compiler.close(). A failed run with no stats therefore skipped cleanup and replaced the original compiler error with a generic stats-is-null error.

## Validation
- yarn check
- yarn test: 40 tests passed
- yarn build
- yarn test:slow: 131 tests passed