### PR TITLE
Use Oxc for Rspack minification

### DIFF
--- a/.changeset/fast-owls-minify.md
+++ b/.changeset/fast-owls-minify.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': minor
+---
+
+Use Oxc with bounded concurrency to minify Rspack JavaScript bundles.

--- a/src/config/OxcJsMinimizerRspackPlugin.ts
+++ b/src/config/OxcJsMinimizerRspackPlugin.ts
@@ -1,0 +1,69 @@
+import { Compilation, sources } from '@rspack/core'
+import type { Compiler, RspackPluginInstance } from '@rspack/core'
+import { minify } from 'oxc-minify'
+import PQueue from 'p-queue'
+
+const PLUGIN_NAME = 'OxcJsMinimizerRspackPlugin'
+const JAVASCRIPT_ASSET = /\.[cm]?js$/
+
+export default class OxcJsMinimizerRspackPlugin implements RspackPluginInstance {
+  apply(compiler: Compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: PLUGIN_NAME,
+          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
+        },
+        async () => {
+          const queue = new PQueue({ concurrency: 4 })
+          const assets = compilation
+            .getAssets()
+            .filter(
+              asset =>
+                JAVASCRIPT_ASSET.test(asset.name) && !asset.info.minimized,
+            )
+
+          const minifications = await Promise.allSettled(
+            assets.map(asset =>
+              queue.add(async () => {
+                const originalCode = asset.source.source().toString()
+                const result = await minify(asset.name, originalCode, {
+                  compress: true,
+                  mangle: true,
+                  codegen: {
+                    legalComments: 'none',
+                    removeWhitespace: true,
+                  },
+                })
+
+                if (result.errors.length > 0) {
+                  throw new Error(
+                    `Oxc could not minify ${asset.name}:\n${result.errors
+                      .map(error => error.message)
+                      .join('\n')}`,
+                  )
+                }
+
+                compilation.updateAsset(
+                  asset.name,
+                  new sources.RawSource(result.code),
+                  assetInfo => ({
+                    ...assetInfo,
+                    minimized: true,
+                  }),
+                )
+              }),
+            ),
+          )
+
+          const failedMinification = minifications.find(
+            result => result.status === 'rejected',
+          )
+          if (failedMinification?.status === 'rejected') {
+            throw failedMinification.reason
+          }
+        },
+      )
+    })
+  }
+}

--- a/src/config/makeRspackConfig.ts
+++ b/src/config/makeRspackConfig.ts
@@ -5,6 +5,8 @@ import type { Entry, Configuration } from '@rspack/core'
 import rspack from '@rspack/core'
 import { createRequire } from 'node:module'
 
+import OxcJsMinimizerRspackPlugin from './OxcJsMinimizerRspackPlugin.js'
+
 const require = createRequire(import.meta.url)
 
 import type { Externals } from '../common.types.js'
@@ -46,13 +48,13 @@ export default function makeRspackConfig({
       runtimeChunk: 'multiple',
       realContentHash: false,
       minimize: minify,
+      minimizer: [
+        new OxcJsMinimizerRspackPlugin(),
+        new rspack.LightningCssMinimizerRspackPlugin(),
+      ],
       // Enable tree-shaking optimizations
       usedExports: true, // Mark unused exports for removal
       sideEffects: true, // Respect package.json sideEffects field
-      // Rspack automatically uses its built-in default minifiers:
-      // - SwcJsMinimizerRspackPlugin for JS (SWC-based, very fast)
-      // - LightningCssMinimizerRspackPlugin for CSS (Lightning CSS-based)
-      // See: https://rspack.rs/guide/optimization/production
       splitChunks: {
         cacheGroups: {
           styles: {

--- a/tests/fast/oxc-js-minimizer.test.ts
+++ b/tests/fast/oxc-js-minimizer.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import { rspack } from '@rspack/core'
+import type { Stats } from '@rspack/core'
+
+import makeRspackConfig from '../../src/config/makeRspackConfig.js'
+
+const temporaryDirectories: string[] = []
+
+async function compile(minify: boolean) {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'package-build-stats-oxc-'),
+  )
+  temporaryDirectories.push(directory)
+
+  const entry = path.join(directory, 'index.js')
+  const outputPath = path.join(directory, 'dist')
+  await fs.writeFile(
+    entry,
+    `
+      // This comment and the descriptive names should be removed.
+      function addTheseNumbersTogether(firstNumber, secondNumber) {
+        return firstNumber + secondNumber
+      }
+      console.log(addTheseNumbersTogether(1, 2))
+    `,
+  )
+
+  const compiler = rspack(
+    makeRspackConfig({
+      packageName: 'fixture',
+      entry,
+      externals: {
+        externalPackages: [],
+        externalBuiltIns: [],
+      },
+      minify,
+      outputPath,
+    }),
+  )
+
+  const stats = await new Promise<Stats>((resolve, reject) => {
+    compiler.run((error, result) => {
+      compiler.close(closeError => {
+        if (closeError) {
+          reject(closeError)
+        } else if (error) {
+          reject(error)
+        } else if (!result) {
+          reject(new Error('Rspack returned no stats'))
+        } else {
+          resolve(result)
+        }
+      })
+    })
+  })
+
+  expect(stats.hasErrors()).toBe(false)
+  return fs.readFile(path.join(outputPath, 'main.bundle.js'), 'utf8')
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map(directory => fs.rm(directory, { recursive: true, force: true })),
+  )
+})
+
+describe('OxcJsMinimizerRspackPlugin', () => {
+  test('minifies JavaScript assets when minification is enabled', async () => {
+    const output = await compile(true)
+
+    expect(output).not.toContain('This comment')
+    expect(output).not.toContain('addTheseNumbersTogether')
+  })
+
+  test('leaves JavaScript assets readable when minification is disabled', async () => {
+    const output = await compile(false)
+
+    expect(output).toContain('addTheseNumbersTogether')
+  })
+})

--- a/tests/slow/functional.test.ts
+++ b/tests/slow/functional.test.ts
@@ -234,10 +234,8 @@ describe('Functional Tests - Package Building & Sizing', () => {
       expect(result.size).toBeWithinDelta(5.76 * 1024, 3 * 1024)
     })
 
-    test('should work with swc minifier', async () => {
-      const result = await getPackageStats('redux@3.7.2', {
-        minifier: 'swc',
-      })
+    test('should work with the default Oxc minifier', async () => {
+      const result = await getPackageStats('redux@3.7.2')
 
       expect(result).toHaveProperty('size')
       expect(result.size).toBeGreaterThan(0)
@@ -365,7 +363,6 @@ describe('Functional Tests - Bundler Comparison', () => {
 
         const rspackResult = await getPackageStats(packageName, {
           bundler: 'rspack',
-          minifier: 'swc',
         })
 
         // Sizes should be within 10% of each other


### PR DESCRIPTION
## Summary

- replace the implicit SWC JavaScript minimizer in Rspack production builds with `oxc-minify`
- bound Oxc work to four concurrent assets to control peak memory
- preserve `minify: false`, retain Lightning CSS minification, and propagate Oxc diagnostics
- update the real-package minifier test and add focused Rspack integration coverage
- add a minor changeset

Dependency-tree size calculation already uses Oxc on `master`; this completes the remaining JavaScript minification path.

## Angular export-size benchmark

Measured locally with 28 exports from `@catull/igniteui-angular@9.0.0-beta6`:

| | Oxc | Rspack default SWC |
| --- | ---: | ---: |
| Build phase | 1.83-1.84s | 2.26-2.40s |
| Aggregate raw output | 42,682,960 B | 42,659,253 B |
| Aggregate gzip output | 8,121,969 B | 8,138,326 B |

Oxc was 19-23% faster. Observed peak memory was 10-21% lower depending on the macOS memory metric and repeat. Output remained effectively equivalent: +0.056% raw and -0.20% gzip.

## Rspack option review

I also measured the plausible export-build options:

- `concatenateModules: false` substantially lowered memory for this Angular package, but Rspack documents a general 4-10% raw-size benefit from scope hoisting. Disabling it would make reported sizes less production-like, so it is not included.
- `mergeDuplicateChunks: false` produced only a marginal improvement.
- `sideEffects: 'flag'` produced no meaningful improvement.
- `avoidEntryIife` is explicitly documented as potentially reducing build performance.
- disabling `usedExports`, `providedExports`, or `innerGraph` would compromise tree-shaken export sizes.

The existing `realContentHash: false` remains enabled.

## Validation

- `yarn check`
- `yarn test` - 42 tests passed
- `yarn build`
- targeted real-package, export-size, and CSS functional tests - 10 tests passed
