### PR TITLE
Build packages that publish TypeScript source

### DIFF
--- a/.changeset/clean-bags-build.md
+++ b/.changeset/clean-bags-build.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': patch
+---
+
+Build packages that publish TypeScript source files.

--- a/src/config/makeRspackConfig.ts
+++ b/src/config/makeRspackConfig.ts
@@ -77,6 +77,10 @@ export default function makeRspackConfig({
       modules: ['node_modules'],
       conditionNames: ['svelte', '...'],
       extensions: [
+        '.web.tsx',
+        '.web.ts',
+        '.tsx',
+        '.ts',
         '.web.mjs',
         '.mjs',
         '.web.js',
@@ -96,6 +100,14 @@ export default function makeRspackConfig({
     },
     module: {
       rules: [
+        {
+          test: /\.tsx?$/,
+          loader: 'builtin:swc-loader',
+          options: {
+            detectSyntax: 'auto',
+          },
+          type: 'javascript/auto',
+        },
         {
           type: 'javascript/auto',
           test: /\.mjs$/,

--- a/tests/fixtures/basic/typescript-dependency/package.json
+++ b/tests/fixtures/basic/typescript-dependency/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "typescript-dependency-fixture",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "type": "module"
+}

--- a/tests/fixtures/basic/typescript-dependency/src/index.js
+++ b/tests/fixtures/basic/typescript-dependency/src/index.js
@@ -1,0 +1,1 @@
+export { getPlatformName } from './platform.ts'

--- a/tests/fixtures/basic/typescript-dependency/src/platform.ts
+++ b/tests/fixtures/basic/typescript-dependency/src/platform.ts
@@ -1,0 +1,5 @@
+export type Platform = 'web' | 'native'
+
+export function getPlatformName(platform: Platform): string {
+  return platform
+}

--- a/tests/fixtures/basic/typescript-source/package.json
+++ b/tests/fixtures/basic/typescript-source/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "typescript-source-fixture",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "type": "module"
+}

--- a/tests/fixtures/basic/typescript-source/src/index.ts
+++ b/tests/fixtures/basic/typescript-source/src/index.ts
@@ -1,0 +1,5 @@
+export type PackageMetadata = {
+  name: string
+}
+
+export { getPackageName } from './metadata'

--- a/tests/fixtures/basic/typescript-source/src/metadata.ts
+++ b/tests/fixtures/basic/typescript-source/src/metadata.ts
@@ -1,0 +1,3 @@
+export function getPackageName(metadata: { name: string }): string {
+  return metadata.name
+}

--- a/tests/slow/typescript-source.test.ts
+++ b/tests/slow/typescript-source.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ *
+ * Regression coverage for packages that publish TypeScript source, including
+ * Expo packages whose JavaScript entry eventually imports expo-modules-core
+ * TypeScript files.
+ */
+
+import path from 'path'
+import { getPackageStats } from '../../src'
+
+describe('Published TypeScript source', () => {
+  test.each([
+    ['a TypeScript package entry', 'typescript-source'],
+    ['TypeScript imported from a JavaScript entry', 'typescript-dependency'],
+  ])('builds %s', async (_scenario, fixtureName) => {
+    const fixturePath = path.resolve(
+      __dirname,
+      `../fixtures/basic/${fixtureName}`,
+    )
+
+    const result = await getPackageStats(fixturePath)
+
+    expect(result.size).toBeGreaterThan(0)
+    expect(result.gzip).toBeGreaterThan(0)
+    expect(result.assets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'main',
+          type: 'js',
+        }),
+      ]),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- resolve published `.ts` and `.tsx` package entry points, including web-specific variants
- transpile TypeScript package source with Rspack’s built-in SWC loader
- cover both direct TypeScript entries and TypeScript reached from JavaScript entries
- add a patch changeset

## Production reproductions

- `expo@54.0.36`: builds successfully (61,224 bytes; 18,562 gzip)
- `expo-font@14.0.12`: builds successfully through the `expo-modules-core` TypeScript path (11,628 bytes; 4,328 gzip)

## Validation

- `yarn check`
- `yarn test` (42 tests)
- `yarn build`
- `yarn test:slow`
- `yarn vitest run tests/slow/typescript-source.test.ts` (2 tests)

Flow and raw JSX handling are intentionally out of scope because they require separate parser/runtime policy decisions.