### PR TITLE
Support cancellation of package builds

### DIFF
--- a/.changeset/tidy-build-cancellation.md
+++ b/.changeset/tidy-build-cancellation.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': minor
+---
+
+Add AbortSignal support so callers can cancel package installers and stop package analysis between build phases.

--- a/src/common.types.ts
+++ b/src/common.types.ts
@@ -14,11 +14,12 @@ type AllOptions = {
   additionalPackages?: Array<string>
   isLocal?: boolean
   installTimeout?: number
+  signal?: AbortSignal
 }
 
 export type BuildPackageOptions = Pick<
   AllOptions,
-  'customImports' | 'splitCustomImports' | 'debug' | 'minify'
+  'customImports' | 'splitCustomImports' | 'debug' | 'minify' | 'signal'
 > & {
   includeDependencySizes: boolean
 }
@@ -36,6 +37,7 @@ export type InstallPackageOptions = Pick<
   | 'isLocal'
   | 'installTimeout'
   | 'debug'
+  | 'signal'
 >
 
 export type GetPackageStatsOptions = Pick<
@@ -47,6 +49,7 @@ export type GetPackageStatsOptions = Pick<
   | 'customImports'
   | 'installTimeout'
   | 'minify'
+  | 'signal'
 >
 
 export type Externals = {

--- a/src/errors/CustomError.ts
+++ b/src/errors/CustomError.ts
@@ -28,6 +28,14 @@ export class BuildError extends CustomError {
   }
 }
 
+export class BuildCancelledError extends CustomError {
+  readonly code = 'BUILD_CANCELLED'
+
+  constructor() {
+    super('BuildCancelledError', 'Package build was cancelled', undefined)
+  }
+}
+
 export class EntryPointError extends CustomError {
   constructor(originalError: unknown, extra?: unknown) {
     super('EntryPointError', originalError, extra)

--- a/src/getPackageExportSizes.ts
+++ b/src/getPackageExportSizes.ts
@@ -6,7 +6,11 @@ import createDebug from 'debug'
 
 const debug = createDebug('bp:worker')
 
-import { getExternals, parsePackageString } from './utils/common.utils.js'
+import {
+  getExternals,
+  parsePackageString,
+  throwIfAborted,
+} from './utils/common.utils.js'
 import { getAllExports } from './utils/exports.utils.js'
 import InstallationUtils from './utils/installation.utils.js'
 import BuildUtils from './utils/build.utils.js'
@@ -28,6 +32,7 @@ async function installPackage(
     limitConcurrency: options.limitConcurrency,
     networkConcurrency: options.networkConcurrency,
     installTimeout: options.installTimeout,
+    signal: options.signal,
   })
 }
 
@@ -37,10 +42,16 @@ export async function getAllPackageExports(
 ) {
   const startTime = performance.now()
   const { name: packageName, normalPath } = parsePackageString(packageString)
-  const installPath = await InstallationUtils.preparePath(packageName)
+  const installPath = await InstallationUtils.preparePath(
+    packageName,
+    options.client,
+    options.signal,
+  )
 
   try {
+    throwIfAborted(options.signal)
     await installPackage(packageString, installPath, options)
+    throwIfAborted(options.signal)
     // The package is installed in node_modules subdirectory
     const packagePath =
       normalPath || path.join(installPath, 'node_modules', packageName)
@@ -49,6 +60,7 @@ export async function getAllPackageExports(
       packagePath,
       packageName,
       installPath, // Pass installPath as base for relative path calculation
+      options.signal,
     )
     Telemetry.packageExports(packageString, startTime, true)
     return results
@@ -70,15 +82,21 @@ export async function getPackageExportSizes(
   const { name: packageName, normalPath } = parsePackageString(packageString)
 
   const preparePathStart = performance.now()
-  const installPath = await InstallationUtils.preparePath(packageName)
+  const installPath = await InstallationUtils.preparePath(
+    packageName,
+    options.client,
+    options.signal,
+  )
   timings.preparePath = performance.now() - preparePathStart
   console.log(
     `[PERF] [ExportSizes] preparePath: ${timings.preparePath.toFixed(2)}ms`,
   )
 
   try {
+    throwIfAborted(options.signal)
     const installStart = performance.now()
     await installPackage(packageString, installPath, options)
+    throwIfAborted(options.signal)
     timings.install = performance.now() - installStart
     console.log(
       `[PERF] [ExportSizes] installPackage: ${timings.install.toFixed(2)}ms`,
@@ -94,7 +112,9 @@ export async function getPackageExportSizes(
       packagePath,
       packageName,
       installPath, // Pass installPath as base for relative path calculation
+      options.signal,
     )
+    throwIfAborted(options.signal)
     timings.getAllExports = performance.now() - getAllExportsStart
     console.log(
       `[PERF] [ExportSizes] getAllExports: ${timings.getAllExports.toFixed(2)}ms`,
@@ -109,6 +129,7 @@ export async function getPackageExportSizes(
 
     const externalsStart = performance.now()
     const externals = getExternals(packageName, installPath)
+    throwIfAborted(options.signal)
     timings.getExternals = performance.now() - externalsStart
     console.log(
       `[PERF] [ExportSizes] getExternals: ${timings.getExternals.toFixed(2)}ms`,
@@ -125,6 +146,7 @@ export async function getPackageExportSizes(
     const ignoredMissingDependenciesSet = new Set<string>()
 
     for (let i = 0; i < buildExports.length; i += chunkSize) {
+      throwIfAborted(options.signal)
       const chunk = buildExports.slice(i, i + chunkSize)
       // Build chunks sequentially to cap Rspack's peak memory usage.
       // oxlint-disable-next-line no-await-in-loop
@@ -136,8 +158,10 @@ export async function getPackageExportSizes(
           customImports: chunk,
           splitCustomImports: true,
           includeDependencySizes: false,
+          signal: options.signal,
         },
       })
+      throwIfAborted(options.signal)
       assets.push(...chunkDetails.assets)
       if (chunkDetails.ignoredMissingDependencies) {
         chunkDetails.ignoredMissingDependencies.forEach(dep => {

--- a/src/getPackageStats.ts
+++ b/src/getPackageStats.ts
@@ -6,7 +6,11 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
-import { getExternals, parsePackageString } from './utils/common.utils.js'
+import {
+  getExternals,
+  parsePackageString,
+  throwIfAborted,
+} from './utils/common.utils.js'
 import InstallationUtils from './utils/installation.utils.js'
 import BuildUtils from './utils/build.utils.js'
 import { UnexpectedBuildError } from './errors/CustomError.js'
@@ -62,11 +66,13 @@ export default async function getPackageStats(
   const installPath = await InstallationUtils.preparePath(
     packageName,
     options.client,
+    options.signal,
   )
   timings.preparePath = performance.now() - preparePathStart
   console.log(`[PERF] preparePath: ${timings.preparePath.toFixed(2)}ms`)
 
   try {
+    throwIfAborted(options.signal)
     const installStart = performance.now()
     await InstallationUtils.installPackage(packageString, installPath, {
       isLocal,
@@ -74,12 +80,15 @@ export default async function getPackageStats(
       limitConcurrency: options.limitConcurrency,
       networkConcurrency: options.networkConcurrency,
       installTimeout: options.installTimeout,
+      signal: options.signal,
     })
+    throwIfAborted(options.signal)
     timings.install = performance.now() - installStart
     console.log(`[PERF] installPackage: ${timings.install.toFixed(2)}ms`)
 
     const externalsStart = performance.now()
     const externals = getExternals(packageName, installPath)
+    throwIfAborted(options.signal)
     timings.getExternals = performance.now() - externalsStart
     console.log(`[PERF] getExternals: ${timings.getExternals.toFixed(2)}ms`)
 
@@ -95,9 +104,11 @@ export default async function getPackageStats(
           minify: options.minify !== false,
           customImports: options.customImports,
           includeDependencySizes: true,
+          signal: options.signal,
         },
       }),
     ])
+    throwIfAborted(options.signal)
     timings.parallelBuild = performance.now() - parallelStart
     console.log(
       `[PERF] parallel (packageJSON + build): ${timings.parallelBuild.toFixed(2)}ms`,

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -18,6 +18,7 @@ import type {
   CreateEntryPointOptions,
 } from '../common.types.js'
 import Telemetry from './telemetry.utils.js'
+import { throwIfAborted } from './common.utils.js'
 
 type CompilePackageArgs = {
   name: string
@@ -26,6 +27,7 @@ type CompilePackageArgs = {
   debug?: boolean
   minify?: boolean
   outputPath: string
+  signal?: AbortSignal
 }
 
 type CompilePackageReturn = {
@@ -158,7 +160,9 @@ const BuildUtils = {
     debug,
     minify,
     outputPath,
+    signal,
   }: CompilePackageArgs) {
+    throwIfAborted(signal)
     const startTime = performance.now()
 
     const options = makeRspackConfig({
@@ -182,6 +186,7 @@ const BuildUtils = {
         }
 
         try {
+          throwIfAborted(signal)
           if (!stats) {
             throw error ?? new Error('stats is null')
           }
@@ -248,6 +253,7 @@ const BuildUtils = {
     externals,
     options,
   }: BuildPackageArgs) {
+    throwIfAborted(options.signal)
     // Package builds run concurrently, so each install owns its build output.
     const outputPath = path.join(installPath, 'build')
     let entry: any = {}
@@ -277,7 +283,9 @@ const BuildUtils = {
       debug: options.debug,
       minify: options.minify,
       outputPath,
+      signal: options.signal,
     })
+    throwIfAborted(options.signal)
 
     const compilationErrors = getCompilationErrors(stats)
 
@@ -301,6 +309,7 @@ const BuildUtils = {
     }
 
     const jsonStatsStartTime = performance.now()
+    throwIfAborted(options.signal)
     const jsonStats = stats.toJson(
       options.includeDependencySizes
         ? DEPENDENCY_STATS_OPTIONS
@@ -317,8 +326,10 @@ const BuildUtils = {
     }
 
     const getAssetStats = async (asset: RspackStatsAsset) => {
+      throwIfAborted(options.signal)
       const bundle = path.join(outputPath, asset.name)
       const bundleContents = await fs.promises.readFile(bundle)
+      throwIfAborted(options.signal)
       const gzip = gzipSync(bundleContents, {}).length
       const matches = asset.name.match(/(.+?)\.bundle\.(.+)$/)
 
@@ -357,11 +368,13 @@ const BuildUtils = {
         )
         .map(getAssetStats) || []
     const assetStats = await Promise.all(assetStatsPromises)
+    throwIfAborted(options.signal)
     Telemetry.assetsGZIPParseTime(packageName, performance.now())
 
     let dependencySizeResults = {}
     if (options.includeDependencySizes) {
       const dependencySizes = await getDependencySizes(packageName, jsonStats)
+      throwIfAborted(options.signal)
       dependencySizeResults = {
         dependencySizes,
       }
@@ -378,6 +391,7 @@ const BuildUtils = {
     installPath,
     options,
   }: BuildPackageArgs): Promise<BuildPackageResultWithIgnored> {
+    throwIfAborted(options.signal)
     const buildStartTime = performance.now()
     let buildIteration = 1
 
@@ -394,6 +408,7 @@ const BuildUtils = {
       })
       return buildResult
     } catch (e) {
+      throwIfAborted(options.signal)
       buildIteration++
       if (
         e instanceof MissingDependencyError &&
@@ -406,6 +421,7 @@ const BuildUtils = {
           externalPackages: externals.externalPackages.concat(missingModules),
         }
 
+        throwIfAborted(options.signal)
         const rebuiltResult = await BuildUtils.buildPackage({
           name,
           externals: newExternals,

--- a/src/utils/common.utils.ts
+++ b/src/utils/common.utils.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import { builtinModules } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
+import { BuildCancelledError } from '../errors/CustomError.js'
 
 const homeDirectory = os.homedir()
 
@@ -29,6 +30,12 @@ export class ProcessExecutionError extends Error {
 
 export const getBuiltInModules = () =>
   builtinModules.flatMap(mod => [mod, 'node:' + mod])
+
+export function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new BuildCancelledError()
+  }
+}
 
 function killProcessTree(child: childProcess.ChildProcess) {
   if (!child.pid) {
@@ -60,7 +67,11 @@ export function exec(
 ): Promise<string> {
   let timerId: NodeJS.Timeout | undefined
   return new Promise<string>((resolve, reject) => {
-    const { maxBuffer = 1024 * 1024, ...spawnOptions } = options
+    const { maxBuffer = 1024 * 1024, signal, ...spawnOptions } = options
+    if (signal?.aborted) {
+      reject(new BuildCancelledError())
+      return
+    }
     const child = childProcess.spawn(command, args, {
       ...spawnOptions,
       detached: process.platform !== 'win32',
@@ -81,6 +92,7 @@ export function exec(
       if (timerId) {
         clearTimeout(timerId)
       }
+      signal?.removeEventListener('abort', onAbort)
       callback()
     }
 
@@ -99,6 +111,18 @@ export function exec(
             Buffer.concat(stderr).toString(),
           ),
         )
+      })
+    }
+
+    const onAbort = () => {
+      finish(() => {
+        try {
+          killProcessTree(child)
+        } catch (error) {
+          reject(error)
+          return
+        }
+        reject(new BuildCancelledError())
       })
     }
 
@@ -122,7 +146,7 @@ export function exec(
       finish(() => reject(error))
     })
 
-    child.once('close', (code, signal) => {
+    child.once('close', (code, exitSignal) => {
       finish(() => {
         const stdoutText = Buffer.concat(stdout).toString()
         const stderrText = Buffer.concat(stderr).toString()
@@ -132,16 +156,22 @@ export function exec(
           reject(
             new ProcessExecutionError(
               stderrText.trim() ||
-                `Command exited with ${signal ? `signal ${signal}` : `code ${code}`}`,
+                `Command exited with ${exitSignal ? `signal ${exitSignal}` : `code ${code}`}`,
               stdoutText,
               stderrText,
               code,
-              signal,
+              exitSignal,
             ),
           )
         }
       })
     })
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
 
     if (timeout) {
       timerId = setTimeout(() => {

--- a/src/utils/exports.utils.ts
+++ b/src/utils/exports.utils.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import Telemetry from './telemetry.utils.js'
+import { throwIfAborted } from './common.utils.js'
 
 // Initialize resolver with ESM-first configuration
 // - main_fields: ["module", "main"] - prioritize ESM entry points
@@ -102,7 +103,9 @@ function getExportsFromStaticExports(staticExports: StaticExport[]): {
 async function resolveModule(
   context: string,
   lookupPath: string,
+  signal?: AbortSignal,
 ): Promise<string> {
+  throwIfAborted(signal)
   const result = resolver.sync(context, lookupPath)
   if (!result.path) {
     throw new Error(`Cannot resolve module '${lookupPath}' from '${context}'`)
@@ -125,10 +128,12 @@ async function walkExportsRecursive(
   visited: Set<string>,
   rootContext?: string,
   _isRootCall: boolean = false,
+  signal?: AbortSignal,
 ): Promise<ResolvedExports> {
+  throwIfAborted(signal)
   // Use rootContext for calculating relative paths, context for resolution
   const root = rootContext || context
-  const resolvedPath = await resolveModule(context, lookupPath)
+  const resolvedPath = await resolveModule(context, lookupPath, signal)
 
   // Avoid circular dependencies
   if (visited.has(resolvedPath)) {
@@ -138,6 +143,7 @@ async function walkExportsRecursive(
 
   // Parse the file to get exports
   const code = await fs.readFile(resolvedPath, 'utf8')
+  throwIfAborted(signal)
   const parseResult = parseSync(resolvedPath, code, {
     sourceType: 'module',
   })
@@ -155,6 +161,7 @@ async function walkExportsRecursive(
 
   // Add direct exports from this module, resolving re-exports to their source files
   for (const exp of exports) {
+    throwIfAborted(signal)
     let sourcePath = resolvedPath
 
     // If this is a re-export (export { foo } from './module.js'), resolve to the source file
@@ -165,8 +172,10 @@ async function walkExportsRecursive(
         sourcePath = await resolveModule(
           path.dirname(resolvedPath),
           exp.moduleRequest,
+          signal,
         )
       } catch {
+        throwIfAborted(signal)
         // If resolution fails, fall back to current file
         sourcePath = resolvedPath
       }
@@ -188,6 +197,8 @@ async function walkExportsRecursive(
       location,
       visited,
       root, // Pass root context through recursion
+      false,
+      signal,
     )
     // Merge star exports into our exports
     Object.keys(starExports).forEach(expKey => {
@@ -196,6 +207,7 @@ async function walkExportsRecursive(
   })
 
   await Promise.all(promises)
+  throwIfAborted(signal)
   return resolvedExports
 }
 
@@ -209,14 +221,17 @@ export async function getAllExports(
   context: string,
   lookupPath: string,
   installPath?: string, // Base path for calculating relative paths (optional)
+  signal?: AbortSignal,
 ) {
   const startTime = performance.now()
   const visited = new Set<string>()
 
   try {
+    throwIfAborted(signal)
     // Read package.json to get the entry point
     const packageJsonPath = path.join(context, 'package.json')
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
+    throwIfAborted(signal)
     // Prefer module field for ESM, fallback to main, then default
     let entryPoint = packageJson.module || packageJson.main || './index.js'
 
@@ -233,6 +248,7 @@ export async function getAllExports(
       visited,
       installPath,
       true,
+      signal,
     )
     Telemetry.walkPackageExportsTree(packageString, startTime, true)
     return results

--- a/src/utils/installation.utils.ts
+++ b/src/utils/installation.utils.ts
@@ -7,8 +7,12 @@ import sanitize from 'sanitize-filename'
 import createDebug from 'debug'
 
 const debug = createDebug('bp:worker')
-import { InstallError, PackageNotFoundError } from '../errors/CustomError.js'
-import { exec, ProcessExecutionError } from './common.utils.js'
+import {
+  BuildCancelledError,
+  InstallError,
+  PackageNotFoundError,
+} from '../errors/CustomError.js'
+import { exec, ProcessExecutionError, throwIfAborted } from './common.utils.js'
 import config from '../config/config.js'
 import { packageManagers } from '../common.types.js'
 import type { InstallPackageOptions, PackageManager } from '../common.types.js'
@@ -20,6 +24,7 @@ async function packLocalPackage(
   packagePath: string,
   installPath: string,
   timeout: number,
+  signal?: AbortSignal,
 ) {
   const output = await exec(
     'npm',
@@ -31,7 +36,7 @@ async function packLocalPackage(
       '--loglevel=error',
       packagePath,
     ],
-    { cwd: installPath, maxBuffer: 1024 * 500 },
+    { cwd: installPath, maxBuffer: 1024 * 500, signal },
     timeout,
   )
   const filename = (JSON.parse(output) as Array<{ filename?: unknown }>)[0]
@@ -97,7 +102,9 @@ const InstallationUtils = {
   async preparePath(
     packageName: string,
     clientOption?: PackageManager | PackageManager[],
+    signal?: AbortSignal,
   ) {
+    throwIfAborted(signal)
     const startTime = performance.now()
     const installPath = InstallationUtils.getInstallPath(packageName)
 
@@ -199,6 +206,9 @@ const InstallationUtils = {
         }
         return
       } catch (error) {
+        if (error instanceof BuildCancelledError) {
+          throw error
+        }
         lastError = error
 
         if (!isLastClient) {
@@ -231,13 +241,18 @@ const InstallationUtils = {
 
     const installStartTime = performance.now()
 
-    const { isLocal, installTimeout = 45000 } = installOptions
+    const { isLocal, installTimeout = 45000, signal } = installOptions
 
     debug('install start %s', packageString)
 
     try {
       const packageToInstall = isLocal
-        ? await packLocalPackage(packageString, installPath, installTimeout)
+        ? await packLocalPackage(
+            packageString,
+            installPath,
+            installTimeout,
+            signal,
+          )
         : packageString
 
       const execStartTime = performance.now()
@@ -247,6 +262,7 @@ const InstallationUtils = {
         {
           cwd: installPath,
           maxBuffer: 1024 * 500,
+          signal,
         },
         installTimeout,
       )
@@ -264,6 +280,9 @@ const InstallationUtils = {
         client: currentClient,
       })
     } catch (err) {
+      if (err instanceof BuildCancelledError) {
+        throw err
+      }
       if (installOptions.debug || process.env.DEBUG_TIMING) {
         console.log(`[INSTALL ERROR] ${currentClient}:`, err)
       }

--- a/tests/fast/build.utils.test.ts
+++ b/tests/fast/build.utils.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { BuildCancelledError } from '../../src/errors/CustomError'
 
 const mockRspack = vi.fn()
 const mockCompilePackage = vi.fn()
@@ -121,6 +122,53 @@ describe('BuildUtils.compilePackage', () => {
         },
       }),
     ).rejects.toBe(runError)
+  })
+
+  test('does not start rspack when its signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    expect(() =>
+      BuildUtils.compilePackage({
+        name: 'demo-package',
+        entry: { main: '/tmp/index.js' },
+        externals: {
+          externalPackages: [],
+          externalBuiltIns: [],
+        },
+        signal: controller.signal,
+      }),
+    ).toThrow(BuildCancelledError)
+    expect(mockRspack).not.toHaveBeenCalled()
+  })
+
+  test('rejects an aborted compile after closing the compiler', async () => {
+    const controller = new AbortController()
+    const close = vi.fn(callback => callback())
+    let finishCompile: ((error: null, stats: any) => void) | undefined
+
+    mockRspack.mockReturnValue({
+      run: (callback: (error: null, stats: any) => void) => {
+        finishCompile = callback
+      },
+      close,
+    })
+
+    const compilation = BuildUtils.compilePackage({
+      name: 'demo-package',
+      entry: { main: '/tmp/index.js' },
+      externals: {
+        externalPackages: [],
+        externalBuiltIns: [],
+      },
+      signal: controller.signal,
+    })
+
+    controller.abort()
+    finishCompile?.(null, { compilation: { errors: [] } })
+
+    await expect(compilation).rejects.toBeInstanceOf(BuildCancelledError)
+    expect(close).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/tests/fast/installation.utils.test.ts
+++ b/tests/fast/installation.utils.test.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { vi } from 'vitest'
 
+import { BuildCancelledError } from '../../src/errors/CustomError.js'
 import InstallationUtils from '../../src/utils/installation.utils.js'
 
 describe('InstallationUtils', () => {
@@ -61,5 +63,25 @@ describe('InstallationUtils', () => {
         'invalid' as 'npm',
       ),
     ).rejects.toThrow('Unsupported package manager: invalid')
+  })
+
+  test('does not try a fallback package manager after cancellation', async () => {
+    const installWithClient = vi
+      .spyOn(InstallationUtils, 'installWithClient')
+      .mockRejectedValue(new BuildCancelledError())
+
+    await expect(
+      InstallationUtils.installPackage('example', '/tmp/unused', {
+        client: ['bun', 'npm'],
+      }),
+    ).rejects.toBeInstanceOf(BuildCancelledError)
+
+    expect(installWithClient).toHaveBeenCalledTimes(1)
+    expect(installWithClient).toHaveBeenCalledWith(
+      'example',
+      '/tmp/unused',
+      expect.objectContaining({ client: 'bun' }),
+      'bun',
+    )
   })
 })

--- a/tests/fast/process-exec.test.ts
+++ b/tests/fast/process-exec.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
+import { BuildCancelledError } from '../../src/errors/CustomError'
 import { exec, type ProcessExecutionError } from '../../src/utils/common.utils'
 
 const isProcessRunning = (pid: number) => {
@@ -87,5 +88,56 @@ describe.runIf(process.platform !== 'win32')('exec process cleanup', () => {
       }
       await fs.rm(temporaryDirectory, { recursive: true, force: true })
     }
+  })
+
+  test('kills descendants when the operation is aborted', async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'package-build-stats-abort-'),
+    )
+    const pidFile = path.join(temporaryDirectory, 'child.pid')
+    const controller = new AbortController()
+    let descendantPid: number | undefined
+
+    try {
+      const command = `sleep 30 & echo $! > "${pidFile}"; wait`
+      const execution = exec('sh', ['-c', command], {
+        signal: controller.signal,
+      })
+
+      while (!descendantPid) {
+        try {
+          // Polling is intentionally sequential until the child publishes its PID.
+          // oxlint-disable-next-line no-await-in-loop
+          descendantPid = Number(await fs.readFile(pidFile, 'utf8'))
+        } catch {
+          // Wait until the shell has started its descendant.
+          // oxlint-disable-next-line no-await-in-loop
+          await new Promise(resolve => setTimeout(resolve, 10))
+        }
+      }
+
+      const startedAt = performance.now()
+      controller.abort()
+
+      await expect(execution).rejects.toBeInstanceOf(BuildCancelledError)
+      expect(performance.now() - startedAt).toBeLessThan(750)
+      expect(await waitForProcessToExit(descendantPid, 1000)).toBe(true)
+    } finally {
+      if (descendantPid && isProcessRunning(descendantPid)) {
+        process.kill(descendantPid, 'SIGKILL')
+      }
+      await fs.rm(temporaryDirectory, { recursive: true, force: true })
+    }
+  })
+
+  test('does not start a command when its signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      exec(process.execPath, ['-e', 'process.exit(1)'], {
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(BuildCancelledError)
   })
 })


### PR DESCRIPTION
## Summary
- add an AbortSignal option to package stats and export analysis APIs
- kill package-manager process groups on cancellation and skip fallback installers
- stop export traversal, Rspack retries, stats parsing, and asset processing at cancellation boundaries
- preserve per-build temporary-directory cleanup and expose a typed BUILD_CANCELLED error

## Verification
- `yarn check`
- `yarn test` (47/47)
- `yarn build`
- `yarn test:slow` (132/133; the remaining pre-existing fixture install is blocked locally by registry responses: Bun gets 404 from packages.atlassian.com for Axios, npm gets 403 from the signed CloudFront tarball URL)