### PR TITLE
Name Rspack asset modules as bundles

### DIFF
--- a/.changeset/friendly-assets-build.md
+++ b/.changeset/friendly-assets-build.md
@@ -1,0 +1,5 @@
+---
+'package-build-stats': patch
+---
+
+Support packages that emit asset modules such as JSON, fonts, and images.

--- a/src/config/makeRspackConfig.ts
+++ b/src/config/makeRspackConfig.ts
@@ -198,6 +198,7 @@ export default function makeRspackConfig({
     },
     output: {
       filename: '[name].bundle.js',
+      assetModuleFilename: '[name].[contenthash:8].bundle[ext]',
       webassemblyModuleFilename: '[hash].bundle.wasm',
       path: outputPath,
     },

--- a/tests/fast/makeRspackConfig.test.ts
+++ b/tests/fast/makeRspackConfig.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import makeRspackConfig from '../../src/config/makeRspackConfig.js'
 
 describe('makeRspackConfig', () => {
-  test('uses the bundle filename convention for WebAssembly modules', () => {
+  test('uses the bundle filename convention for emitted assets', () => {
     const config = makeRspackConfig({
       packageName: 'fixture',
       entry: '/tmp/index.js',
@@ -14,6 +14,9 @@ describe('makeRspackConfig', () => {
       outputPath: '/tmp/output',
     })
 
+    expect(config.output?.assetModuleFilename).toBe(
+      '[name].[contenthash:8].bundle[ext]',
+    )
     expect(config.output?.webassemblyModuleFilename).toBe('[hash].bundle.wasm')
   })
 })


### PR DESCRIPTION
## Summary
- name Rspack asset-module outputs using the existing `.bundle.<extension>` convention
- preserve content hashes to avoid filename collisions
- add a patch changeset and extend the Rspack output regression test

This supersedes #74 with a branch based on current `master`.

## Production reproductions
- `create-hypercolor@0.2.1`: previously rejected `086356b87dfc8832.json`; now builds and reports the JSON asset
- `create-fumadocs-app@16.1.11`: previously rejected `d0e276d531ae3131.js`; now builds and reports the JavaScript asset

## Verification
- `yarn check`
- `yarn test` (49 passed)
- `yarn build`
- end-to-end local builds of both production reproducers