### PR TITLE
Support optional package installation services

### DIFF
--- a/.changeset/tidy-lions-install.md
+++ b/.changeset/tidy-lions-install.md
@@ -1,0 +1,6 @@
+---
+'package-build-stats': minor
+---
+
+Allow analysis functions to use an optional package installation service while
+retaining local installation as the default and fallback.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ const results = await getPackageStats('lodash', { client: 'pnpm' })
 const results = await getPackageStats('lodash', { client: 'yarn' })
 ```
 
+Analysis functions install packages locally by default. A service can instead
+provide a reusable installation without changing those APIs:
+
+```js
+await getPackageStats('lodash', {
+  installationService: { url: 'http://127.0.0.1:7003' },
+})
+```
+
+The service implements `POST /installations` to return
+`{ packageString, packageName, installPath, packagePath }`. Generated entries
+and bundles are written to a separate per-analysis directory, so the returned
+installation can be safely reused. Transport failures fall back to a local
+install unless `fallbackToLocal` is `false`.
+
+The `package-build-stats/installation` subpath exports `installPackage` and
+`disposePackage` for implementing that service. Standalone callers do not need
+an installation service.
+
 #### Passing options to the build
 
 ```js

--- a/package.json
+++ b/package.json
@@ -19,6 +19,18 @@
   ],
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./installation": {
+      "types": "./build/installation.d.ts",
+      "default": "./build/installation.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "scripts": {
     "start": "node index.js",
     "dev": "DEBUG=bp* node --watch index.js",

--- a/src/common.types.ts
+++ b/src/common.types.ts
@@ -1,6 +1,11 @@
 export const packageManagers = ['npm', 'yarn', 'pnpm', 'bun'] as const
 export type PackageManager = (typeof packageManagers)[number]
 
+export type InstallationServiceOptions = {
+  url: string
+  fallbackToLocal?: boolean
+}
+
 type AllOptions = {
   customImports?: Array<string>
   splitCustomImports?: boolean
@@ -15,6 +20,7 @@ type AllOptions = {
   isLocal?: boolean
   installTimeout?: number
   signal?: AbortSignal
+  installationService?: InstallationServiceOptions
 }
 
 export type BuildPackageOptions = Pick<
@@ -38,6 +44,7 @@ export type InstallPackageOptions = Pick<
   | 'installTimeout'
   | 'debug'
   | 'signal'
+  | 'installationService'
 >
 
 export type GetPackageStatsOptions = Pick<
@@ -50,6 +57,7 @@ export type GetPackageStatsOptions = Pick<
   | 'installTimeout'
   | 'minify'
   | 'signal'
+  | 'installationService'
 >
 
 export type Externals = {

--- a/src/config/makeRspackConfig.ts
+++ b/src/config/makeRspackConfig.ts
@@ -4,6 +4,7 @@ import escapeRegex from 'escape-string-regexp'
 import type { Entry, Configuration } from '@rspack/core'
 import rspack from '@rspack/core'
 import { createRequire } from 'node:module'
+import path from 'node:path'
 
 import OxcJsMinimizerRspackPlugin from './OxcJsMinimizerRspackPlugin.js'
 
@@ -17,12 +18,14 @@ type MakeRspackConfigOptions = {
   debug?: boolean
   minify?: boolean
   entry: Entry
+  dependencyPath?: string
   outputPath: string
 }
 
 export default function makeRspackConfig({
   packageName: _packageName,
   entry,
+  dependencyPath,
   externals,
   debug: _debug,
   minify = true,
@@ -74,7 +77,9 @@ export default function makeRspackConfig({
       chunkModules: true,
     },
     resolve: {
-      modules: ['node_modules'],
+      modules: dependencyPath
+        ? [path.join(dependencyPath, 'node_modules'), 'node_modules']
+        : ['node_modules'],
       conditionNames: ['svelte', '...'],
       extensions: [
         '.web.tsx',

--- a/src/getPackageExportSizes.ts
+++ b/src/getPackageExportSizes.ts
@@ -1,60 +1,30 @@
 import Telemetry from './utils/telemetry.utils.js'
 import { performance } from 'node:perf_hooks'
-import path from 'node:path'
 
 import createDebug from 'debug'
 
 const debug = createDebug('bp:worker')
 
-import {
-  getExternals,
-  parsePackageString,
-  throwIfAborted,
-} from './utils/common.utils.js'
+import { getExternals, throwIfAborted } from './utils/common.utils.js'
 import { getAllExports } from './utils/exports.utils.js'
-import InstallationUtils from './utils/installation.utils.js'
 import BuildUtils from './utils/build.utils.js'
 import type {
   GetPackageStatsOptions,
   InstallPackageOptions,
 } from './common.types.js'
-
-async function installPackage(
-  packageString: string,
-  installPath: string,
-  options: InstallPackageOptions,
-) {
-  const { isLocal } = parsePackageString(packageString)
-
-  await InstallationUtils.installPackage(packageString, installPath, {
-    isLocal,
-    client: options.client,
-    limitConcurrency: options.limitConcurrency,
-    networkConcurrency: options.networkConcurrency,
-    installTimeout: options.installTimeout,
-    signal: options.signal,
-  })
-}
+import { preparePackage, type PreparedPackage } from './packageInstallation.js'
 
 export async function getAllPackageExports(
   packageString: string,
   options: InstallPackageOptions = {},
 ) {
   const startTime = performance.now()
-  const { name: packageName, normalPath } = parsePackageString(packageString)
-  const installPath = await InstallationUtils.preparePath(
-    packageName,
-    options.client,
-    options.signal,
-  )
+  let preparedPackage: PreparedPackage | undefined
 
   try {
+    preparedPackage = await preparePackage(packageString, options, false)
+    const { packageName, packagePath, installPath } = preparedPackage
     throwIfAborted(options.signal)
-    await installPackage(packageString, installPath, options)
-    throwIfAborted(options.signal)
-    // The package is installed in node_modules subdirectory
-    const packagePath =
-      normalPath || path.join(installPath, 'node_modules', packageName)
     const results = await getAllExports(
       packageString,
       packagePath,
@@ -68,7 +38,7 @@ export async function getAllPackageExports(
     Telemetry.packageExports(packageString, startTime, false, err)
     throw err
   } finally {
-    await InstallationUtils.cleanupPath(installPath)
+    await preparedPackage?.cleanup()
   }
 }
 
@@ -78,34 +48,17 @@ export async function getPackageExportSizes(
 ) {
   const startTime = performance.now()
   const timings: Record<string, number> = {}
-
-  const { name: packageName, normalPath } = parsePackageString(packageString)
-
-  const preparePathStart = performance.now()
-  const installPath = await InstallationUtils.preparePath(
-    packageName,
-    options.client,
-    options.signal,
-  )
-  timings.preparePath = performance.now() - preparePathStart
-  console.log(
-    `[PERF] [ExportSizes] preparePath: ${timings.preparePath.toFixed(2)}ms`,
-  )
+  let preparedPackage: PreparedPackage | undefined
 
   try {
-    throwIfAborted(options.signal)
     const installStart = performance.now()
-    await installPackage(packageString, installPath, options)
+    preparedPackage = await preparePackage(packageString, options)
+    const { packageName, packagePath, installPath, buildPath } = preparedPackage
     throwIfAborted(options.signal)
     timings.install = performance.now() - installStart
     console.log(
       `[PERF] [ExportSizes] installPackage: ${timings.install.toFixed(2)}ms`,
     )
-
-    // The package is installed in node_modules subdirectory
-    const packagePath =
-      normalPath || path.join(installPath, 'node_modules', packageName)
-
     const getAllExportsStart = performance.now()
     const exportMap = await getAllExports(
       packageString,
@@ -152,7 +105,8 @@ export async function getPackageExportSizes(
       // oxlint-disable-next-line no-await-in-loop
       const chunkDetails = await BuildUtils.buildPackageIgnoringMissingDeps({
         name: packageName,
-        installPath,
+        installPath: buildPath,
+        dependencyPath: installPath,
         externals,
         options: {
           customImports: chunk,
@@ -206,6 +160,6 @@ export async function getPackageExportSizes(
     Telemetry.packageExportsSizes(packageString, startTime, false, options, err)
     throw err
   } finally {
-    await InstallationUtils.cleanupPath(installPath)
+    await preparedPackage?.cleanup()
   }
 }

--- a/src/getPackageStats.ts
+++ b/src/getPackageStats.ts
@@ -6,16 +6,12 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
-import {
-  getExternals,
-  parsePackageString,
-  throwIfAborted,
-} from './utils/common.utils.js'
-import InstallationUtils from './utils/installation.utils.js'
+import { getExternals, throwIfAborted } from './utils/common.utils.js'
 import BuildUtils from './utils/build.utils.js'
 import { UnexpectedBuildError } from './errors/CustomError.js'
 import type { GetPackageStatsOptions } from './common.types.js'
 import Telemetry from './utils/telemetry.utils.js'
+import { preparePackage, type PreparedPackage } from './packageInstallation.js'
 
 function getPackageJSONDetails(packageName: string, installPath: string) {
   const startTime = performance.now()
@@ -59,29 +55,12 @@ export default async function getPackageStats(
 ) {
   const startTime = performance.now()
   const timings: Record<string, number> = {}
-
-  const { name: packageName, isLocal } = parsePackageString(packageString)
-
-  const preparePathStart = performance.now()
-  const installPath = await InstallationUtils.preparePath(
-    packageName,
-    options.client,
-    options.signal,
-  )
-  timings.preparePath = performance.now() - preparePathStart
-  console.log(`[PERF] preparePath: ${timings.preparePath.toFixed(2)}ms`)
+  let preparedPackage: PreparedPackage | undefined
 
   try {
-    throwIfAborted(options.signal)
     const installStart = performance.now()
-    await InstallationUtils.installPackage(packageString, installPath, {
-      isLocal,
-      client: options.client,
-      limitConcurrency: options.limitConcurrency,
-      networkConcurrency: options.networkConcurrency,
-      installTimeout: options.installTimeout,
-      signal: options.signal,
-    })
+    preparedPackage = await preparePackage(packageString, options)
+    const { packageName, installPath, buildPath } = preparedPackage
     throwIfAborted(options.signal)
     timings.install = performance.now() - installStart
     console.log(`[PERF] installPackage: ${timings.install.toFixed(2)}ms`)
@@ -97,7 +76,8 @@ export default async function getPackageStats(
       getPackageJSONDetails(packageName, installPath),
       BuildUtils.buildPackageIgnoringMissingDeps({
         name: packageName,
-        installPath,
+        installPath: buildPath,
+        dependencyPath: installPath,
         externals,
         options: {
           debug: options.debug,
@@ -145,8 +125,6 @@ export default async function getPackageStats(
     )
     throw e
   } finally {
-    if (!options.debug) {
-      await InstallationUtils.cleanupPath(installPath)
-    }
+    await preparedPackage?.cleanup(options.debug)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as getPackageStats } from './getPackageStats.js'
+export type { InstallationServiceOptions } from './common.types.js'
 export * from './errors/CustomError.js'
 export * from './getPackageExportSizes.js'
 export { emitter as eventQueue } from './utils/telemetry.utils.js'

--- a/src/installation.ts
+++ b/src/installation.ts
@@ -1,0 +1,5 @@
+export {
+  disposePackage,
+  installPackage,
+  type PackageInstallation,
+} from './packageInstallation.js'

--- a/src/packageInstallation.ts
+++ b/src/packageInstallation.ts
@@ -1,0 +1,209 @@
+import path from 'node:path'
+import type {
+  InstallationServiceOptions,
+  InstallPackageOptions,
+} from './common.types.js'
+import {
+  BuildCancelledError,
+  InstallError,
+  PackageNotFoundError,
+} from './errors/CustomError.js'
+import { parsePackageString, throwIfAborted } from './utils/common.utils.js'
+import InstallationUtils from './utils/installation.utils.js'
+
+export interface PackageInstallation {
+  packageString: string
+  packageName: string
+  installPath: string
+  packagePath: string
+}
+
+export type PreparedPackage = PackageInstallation & {
+  buildPath: string
+  cleanup(retainLocalFiles?: boolean): Promise<void>
+}
+
+class InstallationServiceUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('Installation service is unavailable', { cause })
+  }
+}
+
+function serviceUrl(service: InstallationServiceOptions, pathname: string) {
+  return `${service.url.replace(/\/$/, '')}${pathname}`
+}
+
+function serializableOptions(options: InstallPackageOptions) {
+  return {
+    client: options.client,
+    limitConcurrency: options.limitConcurrency,
+    networkConcurrency: options.networkConcurrency,
+    additionalPackages: options.additionalPackages,
+    isLocal: options.isLocal,
+    installTimeout: options.installTimeout,
+    debug: options.debug,
+  }
+}
+
+async function requestInstallationService(
+  service: InstallationServiceOptions,
+  pathname: string,
+  init: RequestInit,
+  signal?: AbortSignal,
+) {
+  try {
+    return await fetch(serviceUrl(service, pathname), {
+      ...init,
+      signal,
+    })
+  } catch (error) {
+    if (signal?.aborted) throw new BuildCancelledError()
+    throw new InstallationServiceUnavailableError(error)
+  }
+}
+
+function throwServiceError(payload: unknown): never {
+  const error = payload as {
+    name?: string
+    originalError?: unknown
+    extra?: unknown
+  }
+  if (error?.name === 'PackageNotFoundError') {
+    throw new PackageNotFoundError(error.originalError, error.extra)
+  }
+  throw new InstallError(error?.originalError ?? payload, error?.extra)
+}
+
+function isPackageInstallation(value: unknown): value is PackageInstallation {
+  const installation = value as Partial<PackageInstallation>
+  return (
+    typeof installation?.packageString === 'string' &&
+    typeof installation.packageName === 'string' &&
+    typeof installation.installPath === 'string' &&
+    typeof installation.packagePath === 'string'
+  )
+}
+
+async function getRemoteInstallation(
+  packageString: string,
+  options: InstallPackageOptions,
+): Promise<PackageInstallation> {
+  const service = options.installationService!
+  const response = await requestInstallationService(
+    service,
+    '/installations',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        packageString,
+        options: serializableOptions(options),
+      }),
+    },
+    options.signal,
+  )
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch (error) {
+    throw new InstallationServiceUnavailableError(error)
+  }
+  if ([502, 503, 504].includes(response.status)) {
+    throw new InstallationServiceUnavailableError(payload)
+  }
+  if (!response.ok) throwServiceError(payload)
+  if (!isPackageInstallation(payload)) {
+    throw new InstallationServiceUnavailableError(
+      new Error('Installation service returned an invalid response'),
+    )
+  }
+
+  return payload
+}
+
+/** Installs a package locally and returns the paths needed for analysis. */
+export async function installPackage(
+  packageString: string,
+  options: InstallPackageOptions = {},
+): Promise<PackageInstallation> {
+  throwIfAborted(options.signal)
+  const {
+    name: packageName,
+    normalPath,
+    isLocal,
+  } = parsePackageString(packageString)
+  const installPath = await InstallationUtils.preparePath(
+    packageName,
+    options.client,
+    options.signal,
+  )
+
+  try {
+    await InstallationUtils.installPackage(packageString, installPath, {
+      ...options,
+      installationService: undefined,
+      isLocal,
+    })
+    return {
+      packageString,
+      packageName,
+      installPath,
+      packagePath:
+        normalPath || path.join(installPath, 'node_modules', packageName),
+    }
+  } catch (error) {
+    await InstallationUtils.cleanupPath(installPath)
+    throw error
+  }
+}
+
+/** Removes a locally owned installation. */
+export async function disposePackage(installation: PackageInstallation) {
+  await InstallationUtils.cleanupPath(installation.installPath)
+}
+
+/** Prepares an installation and an isolated directory for generated artifacts. */
+export async function preparePackage(
+  packageString: string,
+  options: InstallPackageOptions = {},
+  needsBuildPath = true,
+): Promise<PreparedPackage> {
+  throwIfAborted(options.signal)
+  if (options.installationService) {
+    try {
+      const installation = await getRemoteInstallation(packageString, options)
+      const buildPath = needsBuildPath
+        ? await InstallationUtils.prepareBuildPath(
+            installation.packageName,
+            options.signal,
+          )
+        : installation.installPath
+      return {
+        ...installation,
+        buildPath,
+        async cleanup(retainLocalFiles = false) {
+          if (needsBuildPath && !retainLocalFiles) {
+            await InstallationUtils.cleanupPath(buildPath)
+          }
+        },
+      }
+    } catch (error) {
+      if (
+        !(error instanceof InstallationServiceUnavailableError) ||
+        options.installationService.fallbackToLocal === false
+      ) {
+        throw error
+      }
+    }
+  }
+
+  const installation = await installPackage(packageString, options)
+  return {
+    ...installation,
+    buildPath: installation.installPath,
+    async cleanup(retainLocalFiles = false) {
+      if (!retainLocalFiles) await disposePackage(installation)
+    },
+  }
+}

--- a/src/utils/build.utils.ts
+++ b/src/utils/build.utils.ts
@@ -24,6 +24,7 @@ type CompilePackageArgs = {
   name: string
   externals: Externals
   entry: Entry
+  dependencyPath: string
   debug?: boolean
   minify?: boolean
   outputPath: string
@@ -40,6 +41,7 @@ type Compiler = NonNullable<ReturnType<typeof rspack>>
 type BuildPackageArgs = {
   name: string
   installPath: string
+  dependencyPath?: string
   externals: Externals
   options: BuildPackageOptions
 }
@@ -156,6 +158,7 @@ const BuildUtils = {
   compilePackage({
     name,
     entry,
+    dependencyPath,
     externals,
     debug,
     minify,
@@ -169,6 +172,7 @@ const BuildUtils = {
       packageName: name,
       entry,
       externals,
+      dependencyPath,
       debug,
       minify,
       outputPath,
@@ -250,11 +254,12 @@ const BuildUtils = {
   async buildPackage({
     name: packageName,
     installPath,
+    dependencyPath = installPath,
     externals,
     options,
   }: BuildPackageArgs) {
     throwIfAborted(options.signal)
-    // Package builds run concurrently, so each install owns its build output.
+    // Concurrent analyses share dependencies but own separate artifact paths.
     const outputPath = path.join(installPath, 'build')
     let entry: any = {}
 
@@ -280,6 +285,7 @@ const BuildUtils = {
       name: packageName,
       entry,
       externals,
+      dependencyPath,
       debug: options.debug,
       minify: options.minify,
       outputPath,
@@ -389,6 +395,7 @@ const BuildUtils = {
     name,
     externals,
     installPath,
+    dependencyPath,
     options,
   }: BuildPackageArgs): Promise<BuildPackageResultWithIgnored> {
     throwIfAborted(options.signal)
@@ -400,6 +407,7 @@ const BuildUtils = {
         name,
         externals,
         installPath,
+        dependencyPath,
         options,
       })
       Telemetry.buildPackage(name, true, buildStartTime, {
@@ -426,6 +434,7 @@ const BuildUtils = {
           name,
           externals: newExternals,
           installPath,
+          dependencyPath,
           options,
         })
 

--- a/src/utils/installation.utils.ts
+++ b/src/utils/installation.utils.ts
@@ -90,11 +90,11 @@ function getInstallArgs(
 }
 
 const InstallationUtils = {
-  getInstallPath(packageName: string) {
+  getInstallPath(packageName: string, directory = 'packages') {
     const id = randomUUID().slice(0, 8)
     return path.join(
       config.tmp,
-      'packages',
+      directory,
       sanitize(`build-${packageName}-${id}`),
     )
   },
@@ -103,10 +103,11 @@ const InstallationUtils = {
     packageName: string,
     clientOption?: PackageManager | PackageManager[],
     signal?: AbortSignal,
+    directory = 'packages',
   ) {
     throwIfAborted(signal)
     const startTime = performance.now()
-    const installPath = InstallationUtils.getInstallPath(packageName)
+    const installPath = InstallationUtils.getInstallPath(packageName, directory)
 
     if (process.env.DEBUG_TIMING) {
       console.log(
@@ -162,6 +163,15 @@ const InstallationUtils = {
     }
 
     return installPath
+  },
+
+  async prepareBuildPath(packageName: string, signal?: AbortSignal) {
+    return InstallationUtils.preparePath(
+      packageName,
+      undefined,
+      signal,
+      'artifacts',
+    )
   },
 
   async installPackage(

--- a/tests/slow/package-installation.test.ts
+++ b/tests/slow/package-installation.test.ts
@@ -1,0 +1,71 @@
+import path from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { getPackageExportSizes, getPackageStats } from '../../src/index.js'
+import { disposePackage, installPackage } from '../../src/installation.js'
+import InstallationUtils from '../../src/utils/installation.utils.js'
+
+const fixturePath = path.resolve(__dirname, '../fixtures/exports/multi-exports')
+
+describe('package installation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  test('builds against a service installation in an isolated artifact directory', async () => {
+    const installation = await installPackage(fixturePath)
+    const localInstall = vi.spyOn(InstallationUtils, 'installPackage')
+    const buildPath = vi.spyOn(InstallationUtils, 'prepareBuildPath')
+    const fetchMock = vi.fn(async () => Response.json(installation))
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      const options = {
+        installationService: { url: 'http://installation-service.test' },
+      }
+      const [stats, exportSizes] = await Promise.all([
+        getPackageStats(fixturePath, options),
+        getPackageExportSizes(fixturePath, options),
+      ])
+
+      expect(stats.size).toBeGreaterThan(0)
+      expect(exportSizes.assets.length).toBeGreaterThan(0)
+      expect(localInstall).not.toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://installation-service.test/installations',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(buildPath).toHaveBeenCalledTimes(2)
+      const artifactPaths = await Promise.all(
+        buildPath.mock.results.map(result => result.value),
+      )
+      expect(new Set(artifactPaths).size).toBe(2)
+      expect(artifactPaths).not.toContain(installation.installPath)
+    } finally {
+      await disposePackage(installation)
+    }
+  })
+
+  test('falls back locally unless the installation service is required', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    const localInstall = vi.spyOn(InstallationUtils, 'installPackage')
+
+    await expect(
+      getPackageStats(fixturePath, {
+        installationService: { url: 'http://installation-service.test' },
+      }),
+    ).resolves.toMatchObject({ size: expect.any(Number) })
+    expect(localInstall).toHaveBeenCalledTimes(1)
+
+    await expect(
+      getPackageStats(fixturePath, {
+        installationService: {
+          url: 'http://installation-service.test',
+          fallbackToLocal: false,
+        },
+      }),
+    ).rejects.toThrow('Installation service is unavailable')
+    expect(localInstall).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- optionally obtain a completed package installation through one `POST /installations` request
- reuse the returned installation as a read-only dependency root while writing entries and bundles to a unique per-analysis artifact directory
- preserve local self-installation as the default and transport fallback
- expose only `installPackage` and `disposePackage` from `package-build-stats/installation` for service implementations

## Why

Bundlephobia's stats, exports, and export-size operations are separate jobs. They should reuse the expensive `node_modules` installation without sharing mutable Rspack entries or outputs.

Package-build-stats deliberately forwards the caller's package spec to the optional installation service. The service that owns installation may resolve a tag or range immediately before installing, then deduplicate and persist by the resulting exact version. Package-build-stats does not require Bundlephobia or another caller to pre-resolve it.

The resulting contract is deliberately small:

1. `POST /installations` with `{ packageString, options }`
2. wait for `{ packageString, packageName, installPath, packagePath }`
3. read dependencies from that installation
4. write generated files to a unique temporary artifact directory and remove it in `finally`

There are no remote leases, release requests, workspace symlinks, Redis objects, or installed-package variants of the public analysis functions. Without `installationService`, every function follows its existing local lifecycle.

## Isolation and compatibility

- the existing high-level function names, signatures, defaults, and analysis bodies remain intact
- `resolve.modules` receives the shared installation's absolute `node_modules`, while entries and Rspack output use the per-analysis directory
- export discovery is read-only and does not create an artifact directory
- valid installation errors remain authoritative; only service availability failures fall back locally
- caller cancellation is passed directly to the HTTP request
- the package exports map retains `./*`, so existing deep imports are not blocked

## Popular-package validation

This exact branch was loaded into the final Bundlephobia installation and build services. For each exact package version, stats, exports, and export sizes reused one deterministic installation. After all 30 analyses, the service contained exactly ten installations, its queue was empty, and `/tmp/tmp-build/artifacts` contained zero directories.

| Repository/package | Minified bytes | Gzip bytes | Discovered exports | Export assets | Installations |
|---|---:|---:|---:|---:|---:|
| sindresorhus/ky (`ky@1.10.0`) | 11,482 | 4,087 | 3 | 2 | 1 |
| facebook/react (`react@19.1.1`) | 7,687 | 2,932 | 0 | 0 | 1 |
| ReactiveX/rxjs (`rxjs@7.8.2`) | 63,664 | 17,628 | 173 | 173 | 1 |
| date-fns/date-fns (`date-fns@4.1.0`) | 72,102 | 17,874 | 251 | 250 | 1 |
| ai/nanoid (`nanoid@5.1.5`) | 694 | 463 | 5 | 5 | 1 |
| uuidjs/uuid (`uuid@11.1.0`) | 10,239 | 3,928 | 14 | 14 | 1 |
| pmndrs/zustand (`zustand@5.0.7`) | 852 | 487 | 0 | 0 | 1 |
| chalk/chalk (`chalk@5.4.1`) | 5,606 | 2,433 | 13 | 12 | 1 |
| iamkun/dayjs (`dayjs@1.11.13`) | 7,175 | 3,064 | 0 | 0 | 1 |
| epoberezkin/fast-deep-equal (`fast-deep-equal@3.1.3`) | 891 | 439 | 0 | 0 | 1 |

## Verification

- `yarn check`
- `yarn test`: 49 tests passed
- `yarn test:slow`: 135 tests passed
- `yarn build`
- concurrent stats and export-size integration test against one service installation
- live exact-version reuse survived an installation-service stop/start with the same deterministic path
- with the final Bundlephobia service, `ky@latest` resolved to `ky@2.0.2` and reused the same path as a subsequent `ky@2.0.2` request
